### PR TITLE
pgremapper: Consider upmaps when reordering up sets.

### DIFF
--- a/backfillstate.go
+++ b/backfillstate.go
@@ -92,7 +92,10 @@ func (bs *backfillState) accountForRemap(pgid string, from, to int) {
 	if !found {
 		panic(fmt.Sprintf("%s: osd %d not in up set", pgid, from))
 	}
-	reorderUpToMatchActing(pgb.Up, pgb.Acting)
+	// Pass nil for the pui here as we don't need to strictly re-order the
+	// up set; it's sufficient to consider which OSDs are listed in up and
+	// acting by themselves.
+	reorderUpToMatchActing(nil, pgb.Up, pgb.Acting)
 
 	bs.addReservations(pgb)
 }

--- a/backfillstate_test.go
+++ b/backfillstate_test.go
@@ -29,6 +29,7 @@ func TestBackfillState(t *testing.T) {
  { "pgid": "1.04", "up": [ 8, 5, 6 ],  "acting": [ 77, 5, 7 ] }
 ]
 `
+	runOsdDump = func() (string, error) { return "{}", nil }
 	runPgDumpPgsBrief = func() (string, error) { return pgDumpOut, nil }
 
 	bs := mustGetCurrentBackfillState()

--- a/main.go
+++ b/main.go
@@ -1004,7 +1004,9 @@ func confirmProceed() bool {
 		return true
 	}
 
+	fmt.Println("The following changes would be made to the upmap exception table:")
 	fmt.Println(M.String())
+	fmt.Println("No changes made - use --yes to apply changes.")
 
 	return false
 }

--- a/main.go
+++ b/main.go
@@ -622,6 +622,7 @@ func getCephStatus() (*cephStatus, error) {
 
 func calcPgMappingsToUndoBackfill(excludeBackfilling bool, excludedOsds, includedOsds, pgsIncludingOsds map[int]struct{}) {
 	pgBriefs := pgDumpPgsBrief()
+	puis := pgUpmapItemMap()
 
 	excluded := func(osd int) bool {
 		_, ok := excludedOsds[osd]
@@ -666,7 +667,7 @@ func calcPgMappingsToUndoBackfill(excludeBackfilling bool, excludedOsds, include
 						// acting set via a PG query.
 						pqo := pgQuery(id)
 						acting = pqo.getCompletePeers()
-						reorderUpToMatchActing(up, acting)
+						reorderUpToMatchActing(puis[pgb.PgID], up, acting)
 						break
 					}
 				}

--- a/main_test.go
+++ b/main_test.go
@@ -41,14 +41,16 @@ func TestCalcPgMappingsToUndoBackfill(t *testing.T) {
  { "pgid": "1.8f", "up": [ 33, 36, 30], "acting": [ 33, 37, 31 ], "state": "backfill_wait" },
  { "pgid": "1.90", "up": [ 33, 36, 30], "acting": [ 33, 37, 31 ], "state": "backfill_wait" },
  { "pgid": "1.91", "up": [ 33, 36, 30], "acting": [ 33, 37, 2147483647 ], "state": "backfill_wait" },
- { "pgid": "1.92", "up": [ 3, 6, 1], "acting": [ 1, 2147483647, 3 ], "state": "backfill_wait" }
+ { "pgid": "1.92", "up": [ 3, 6, 1], "acting": [ 1, 2147483647, 3 ], "state": "backfill_wait" },
+ { "pgid": "1.93", "up": [ 1, 4, 5], "acting": [ 1, 2, 3 ], "state": "backfill_wait" }
 ]
 `
 	osdDumpOut := `
 {
   "pg_upmap_items": [
     { "pgid": "1.8f", "mappings": [ { "from": 37, "to": 36 } ] },
-    { "pgid": "1.90", "mappings": [ { "from": 37, "to": 36 }, { "from": 31, "to": 30 } ] }
+    { "pgid": "1.90", "mappings": [ { "from": 37, "to": 36 }, { "from": 31, "to": 30 } ] },
+    { "pgid": "1.93", "mappings": [ { "from": 3, "to": 4 }, { "from": 2, "to": 5 } ] }
   ]
 }
 `
@@ -126,6 +128,7 @@ func TestCalcPgMappingsToUndoBackfill(t *testing.T) {
 				{ID: "1.8f", Mappings: []mapping{{From: 30, To: 31, dirty: true}}},
 				{ID: "1.90", Mappings: []mapping{}},
 				{ID: "1.91", Mappings: []mapping{{From: 36, To: 37, dirty: true}, {From: 30, To: 38, dirty: true}}},
+				{ID: "1.93", Mappings: []mapping{}},
 			},
 		},
 		{


### PR DESCRIPTION
Consider the following upmap entry:
```
        {
            "pgid": "1.38f",
            "mappings": [
                {
                    "from": 51,
                    "to": 3
                },
                {
                    "from": 19,
                    "to": 11
                }
            ]
        },
```

And the following PG state:
```
        {
            "pgid": "1.38f",
            "state": "active+remapped+backfill_wait",
            "up": [
                3,
                66,
                11
            ],
            "acting": [
                3,
                19,
                39
            ],
            "up_primary": 3,
            "acting_primary": 3
        },
```

Prior to this change, pgremapper would attempt to remap 66->19, which would conflict with the existing mapping 19->11. After this change, pgremapper is wise enough to use the upmap item to realize that 19 and 11 are paired and re-order the up set accordingly for proper processing.