### PR TITLE
ceph: Exclude 'out' OSDs in getOsdsForBucket().

### DIFF
--- a/ceph.go
+++ b/ceph.go
@@ -57,10 +57,11 @@ type osdDumpOut struct {
 }
 
 type osdTreeOutNode struct {
-	ID       int    `json:"id"`
-	Type     string `json:"type"`
-	Name     string `json:"name"`
-	Children []int  `json:"children"`
+	ID       int     `json:"id"`
+	Type     string  `json:"type"`
+	Name     string  `json:"name"`
+	Reweight float64 `json:"reweight"`
+	Children []int   `json:"children"`
 }
 
 type osdTreeOut struct {
@@ -68,9 +69,10 @@ type osdTreeOut struct {
 }
 
 type osdTreeNode struct {
-	ID   int
-	Name string
-	Type string
+	ID       int
+	Name     string
+	Type     string
+	Reweight float64
 
 	Parent   *osdTreeNode
 	Children []*osdTreeNode
@@ -283,6 +285,10 @@ func getOsdsForBucket(bucket string) ([]int, error) {
 			osds = append(osds, mustGetOsdsForBucket(c.Name)...)
 			continue
 		}
+		if c.Reweight == 0 {
+			// This OSD is 'out' - exclude it.
+			continue
+		}
 		osds = append(osds, c.ID)
 	}
 	return osds, nil
@@ -405,9 +411,10 @@ func osdTree() *parsedOsdTree {
 	// First, build direct lookup mappings.
 	for _, n := range out.Nodes {
 		node := &osdTreeNode{
-			ID:   n.ID,
-			Name: n.Name,
-			Type: n.Type,
+			ID:       n.ID,
+			Name:     n.Name,
+			Type:     n.Type,
+			Reweight: n.Reweight,
 		}
 		tree.IDToNode[n.ID] = node
 		tree.NameToNode[n.Name] = node

--- a/main_test.go
+++ b/main_test.go
@@ -685,13 +685,14 @@ func TestParseMaxBackfillReservations(t *testing.T) {
 {
   "nodes": [
     {
-      "children": [ 0, 1 ],
+      "children": [ 0, 1, 2 ],
       "type": "host",
       "name": "host1",
       "id": -4
     },
-    { "type": "osd", "name": "osd.0", "id": 0 },
-    { "type": "osd", "name": "osd.1", "id": 1 }
+    { "type": "osd", "name": "osd.0", "id": 0, "reweight": 0.123 },
+    { "type": "osd", "name": "osd.1", "id": 1, "reweight": 1.00000 },
+    { "type": "osd", "name": "osd.2", "id": 2, "reweight": 0 }
   ]
 }
 `
@@ -705,6 +706,7 @@ func TestParseMaxBackfillReservations(t *testing.T) {
 	mustParseMaxBackfillReservations(cmd)
 
 	require.Equal(t, 10, M.bs.getMaxBackfillReservations(1))
+	// 'out' OSDs are excluded from osdspecs.
 	require.Equal(t, 4, M.bs.getMaxBackfillReservations(2))
 	require.Equal(t, 6, M.bs.getMaxBackfillReservations(133))
 }


### PR DESCRIPTION
We can't perform any remapping operations on 'out' OSDs; they're never in any 'up' sets and can't be upmapped to or from.