### PR TITLE
cancel-backfill: Handle the case where the up set is incomplete.

### DIFF
--- a/main.go
+++ b/main.go
@@ -688,7 +688,11 @@ func calcPgMappingsToUndoBackfill(excludeBackfilling bool, excludedOsds, include
 				// Calculate acting set difference and remap to
 				// avoid any ensuing backfill.
 				for i := range acting {
-					if up[i] != acting[i] && acting[i] != invalidOSD {
+					if up[i] != acting[i] {
+						if up[i] == invalidOSD || acting[i] == invalidOSD {
+							continue
+						}
+
 						if excluded(up[i]) || excluded(acting[i]) {
 							continue
 						}


### PR DESCRIPTION
If an OSD is down, the up map may have a placeholder in it. Skip such entries when computing upmaps.