### PR TITLE
ceph: Filter out PGs that we can't reason about.

### DIFF
--- a/ceph.go
+++ b/ceph.go
@@ -339,6 +339,7 @@ func pgDumpPgsBrief() []*pgBriefItem {
 }
 
 func sanitizePgBriefs(pgBriefs []*pgBriefItem) []*pgBriefItem {
+	duplicateMessage := "WARNING: PG %s's %s set has one or more duplicated OSD IDs; this PG will be excluded from operations and reservation calculations. Please check your CRUSH rules and map.\n"
 	sanitized := make([]*pgBriefItem, 0, len(pgBriefs))
 
 	for _, pgBrief := range pgBriefs {
@@ -346,10 +347,35 @@ func sanitizePgBriefs(pgBriefs []*pgBriefItem) []*pgBriefItem {
 			fmt.Printf("WARNING: PG %s's up and acting sets have mismatched lengths (%d vs. %d), perhaps due to a change in CRUSH rules; this PG will be excluded from operations and reservation calculations.\n", pgBrief.PgID, len(pgBrief.Up), len(pgBrief.Acting))
 			continue
 		}
+
+		if hasDuplicateOSDID(pgBrief.Acting) {
+			fmt.Printf(duplicateMessage, pgBrief.PgID, "acting")
+			continue
+		}
+
+		if hasDuplicateOSDID(pgBrief.Up) {
+			fmt.Printf(duplicateMessage, pgBrief.PgID, "up")
+			continue
+		}
+
 		sanitized = append(sanitized, pgBrief)
 	}
 
 	return sanitized
+}
+
+func hasDuplicateOSDID(osdids []int) bool {
+	for i, osdid := range osdids {
+		for j, otherOSDID := range osdids {
+			if i == j {
+				continue
+			}
+			if osdid == otherOSDID {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 func reorderUpToMatchActing(pui *pgUpmapItem, up, acting []int) {

--- a/main_test.go
+++ b/main_test.go
@@ -25,6 +25,7 @@ import (
 func TestCalcPgMappingsToUndoBackfill(t *testing.T) {
 	// Corner-case PG states included to ensure we handle them gracefully:
 	// * 1.999[01]: up and acting sets have different lengths
+	// * 1.999[23]: up/acting set has duplicate OSDs
 	pgDumpOut := `
 [
  { "pgid": "1.32", "up": [ 7, 5, 9], "acting": [ 7, 5, 9 ] },
@@ -47,7 +48,9 @@ func TestCalcPgMappingsToUndoBackfill(t *testing.T) {
  { "pgid": "1.93", "up": [ 1, 4, 5], "acting": [ 1, 2, 3 ], "state": "backfill_wait" },
 
  { "pgid": "1.9990", "up": [ 1 ], "acting": [ 1, 2, 3 ], "state": "backfill_wait" },
- { "pgid": "1.9991", "up": [ 1, 2, 3 ], "acting": [ 1 ], "state": "backfill_wait" }
+ { "pgid": "1.9991", "up": [ 1, 2, 3 ], "acting": [ 1 ], "state": "backfill_wait" },
+ { "pgid": "1.9992", "up": [ 1, 2, 3 ], "acting": [ 1, 4, 4 ], "state": "backfill_wait" },
+ { "pgid": "1.9993", "up": [ 1, 4, 4 ], "acting": [ 1, 2, 3 ], "state": "backfill_wait" }
 ]
 `
 	osdDumpOut := `


### PR DESCRIPTION
Addresses the remaining issues with some corner-case PG states in https://github.com/digitalocean/pgremapper/issues/14.