### PR TITLE
Don't consider the "invalid" OSD in duplicate-OSD checks.

### DIFF
--- a/ceph.go
+++ b/ceph.go
@@ -380,6 +380,9 @@ func sanitizePgBriefs(pgBriefs []*pgBriefItem) []*pgBriefItem {
 
 func hasDuplicateOSDID(osdids []int) bool {
 	for i, osdid := range osdids {
+		if osdid == invalidOSD {
+			continue
+		}
 		for j, otherOSDID := range osdids {
 			if i == j {
 				continue


### PR DESCRIPTION
The point of this check is to find real duplicates, and thus this placeholder should not be counted.