### PR TITLE
Added device-class filter for balance-bucket command

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ $ ./pgremapper balance-bucket <bucket> [--max-backfills <n>] [--target-spread <n
 ```
 
 * `<bucket>`: A CRUSH bucket that directly contains OSDs.
+* `--device-class`: The device class filter, balance only OSDs with this device class.
 * `--max-backfills`: The total number of backfills that should be allowed to be scheduled that affect this CRUSH bucket. This takes pre-existing backfills into account.
 * `--target-spread`: The goal state in terms of the maximum difference in PG counts across OSDs in this bucket.
 
@@ -86,6 +87,11 @@ $ ./pgremapper balance-bucket <bucket> [--max-backfills <n>] [--target-spread <n
 Schedule 10 backfills on the host named `data11`, trying to achieve a maximum PG spread of 3 between the fullest and emptiest OSDs (in terms of PG counts) within that host:
 ```
 $ ./pgremapper balance-bucket data11 --max-backfills 10 --target-spread 3
+```
+
+Balance host named `data11`, use OSDs with `nvme` device class only:
+```
+$ ./pgremapper balance-bucket data11 --device-class nvme
 ```
 
 ### cancel-backfill
@@ -144,7 +150,7 @@ Remap PGs off of the given source OSD, up to the given maximum number of schedul
 $ ./pgremapper drain <source OSD> --target-osds <osdspec>[,<osdspec>] [--allow-movement-across <bucket type>] [--max-backfill-reservations default_max[,osdspec:max]] [--max-source-backfills <n>]
 ```
 
-* `<source OSD>`: The OSD that will become the backfill source. 
+* `<source OSD>`: The OSD that will become the backfill source.
 * `--target-osds`: The OSD(s) that will become the backfill target(s).
 * `--allow-movement-across`: Constrain which type of data movements will be considered if target OSDs are given outside of the CRUSH bucket that contains the source OSD. For example, if your OSDs all live in a CRUSH bucket of type `host`, passing `host` here will allow remappings across hosts as long as the source and target host live within the same CRUSH bucket themselves. Target CRUSH buckets will be not be considered for a given PG if they already contain replicas/chunks of that PG. By default, if this option isn't given, data movements are allowed only within the direct CRUSH bucket containing the source OSD.
 * `--max-backfill-reservations`: Consume only the given reservation maximums for backfill. You'll commonly want to set this below your `osd-max-backfills` setting so that any scheduled recoveries may clear without waiting for a backfill to complete. A default value is specified first, and then per-`osdspec` values for cases where you want to allow more backfill or have non-uniform `osd-max-backfills` settings.

--- a/main.go
+++ b/main.go
@@ -67,7 +67,7 @@ or is undesirable. The given CRUSH bucket must directly contain OSDs.
 				return errors.New("a bucket must be specified")
 			}
 
-			if _, err := getOsdsForBucket(args[0]); err != nil {
+			if _, err := getOsdsForBucket(args[0], ""); err != nil {
 				return errors.Wrapf(err, "error validating '%s' as a bucket containing OSDs", args[0])
 			}
 
@@ -75,7 +75,9 @@ or is undesirable. The given CRUSH bucket must directly contain OSDs.
 		},
 		Run: func(cmd *cobra.Command, args []string) {
 			M = mustGetCurrentMappingState()
-			osds := mustGetOsdsForBucket(args[0])
+			deviceClass := mustGetString(cmd, "device-class")
+
+			osds := mustGetOsdsForBucket(args[0], deviceClass)
 
 			maxBackfills := mustGetInt(cmd, "max-backfills")
 			targetSpread := mustGetInt(cmd, "target-spread")
@@ -521,7 +523,7 @@ func parseOsdSpec(s string) ([]int, error) {
 		return errResponse(s)
 	}
 
-	osds, err := getOsdsForBucket(spl[1])
+	osds, err := getOsdsForBucket(spl[1], "")
 	if err != nil {
 		return nil, err
 	}
@@ -570,6 +572,8 @@ func init() {
 
 	balanceBucketCmd.Flags().Int("max-backfills", 5, "max number of backfills to schedule for this bucket, including pre-existing ones")
 	balanceBucketCmd.Flags().Int("target-spread", 1, "target difference between the fullest and emptiest OSD in the bucket")
+	balanceBucketCmd.Flags().String("device-class", "", "device class filter, balance only OSDs with this device class")
+
 	rootCmd.AddCommand(balanceBucketCmd)
 
 	cancelBackfillCmd.Flags().Bool("exclude-backfilling", false, "don't interrupt already-started backfills")

--- a/main_test.go
+++ b/main_test.go
@@ -728,6 +728,45 @@ func TestParseMaxBackfillReservations(t *testing.T) {
 	require.Equal(t, 6, M.bs.getMaxBackfillReservations(133))
 }
 
+func TestDeviceClassFilter(t *testing.T) {
+	defer teardownTest(t)
+	osdTreeOut := `
+	{
+		"nodes": [
+		  { "id": -1, "name": "default", "type": "root", "children": [-4] },
+		  { "id": -4, "name": "datacenter1", "type": "datacenter", "children": [-3] },
+		  { "id": -3, "name": "rack1", "type": "rack", "children": [-31, -6, -5, -2] },
+		  { "id": -2, "name": "host1", "type": "host", "children": [2, 1, 0] },
+		  { "id": 0, "device_class": "green", "name": "osd.0", "type": "osd", "reweight": 1 },
+		  { "id": 1, "device_class": "red", "name": "osd.1", "type": "osd", "reweight": 1 },
+		  { "id": 2, "device_class": "blue", "name": "osd.2", "type": "osd", "reweight": 1 },
+		  { "id": -5, "name": "host2", "type": "host", "children": [6, 4, 3] },
+		  { "id": 3, "device_class": "green", "name": "osd.3", "type": "osd", "reweight": 1 },
+		  { "id": 4, "device_class": "red", "name": "osd.4", "type": "osd", "reweight": 1 },
+		  { "id": 6, "device_class": "blue", "name": "osd.6", "type": "osd", "reweight": 1 },
+		  { "id": -6, "name": "host3", "type": "host", "children": [8, 7, 5] },
+		  { "id": 5, "device_class": "green", "name": "osd.5", "type": "osd", "reweight": 1 },
+		  { "id": 7, "device_class": "red", "name": "osd.7", "type": "osd", "reweight": 1 },
+		  { "id": 8, "device_class": "blue", "name": "osd.8", "type": "osd", "reweight": 1 },
+		  { "id": -31, "name": "host4", "type": "host", "children": [11, 10, 9] },
+		  { "id": 9, "device_class": "green", "name": "osd.9", "type": "osd", "reweight": 1 },
+		  { "id": 10, "device_class": "red", "name": "osd.10", "type": "osd", "reweight": 1 },
+		  { "id": 11, "device_class": "blue", "name": "osd.11", "type": "osd", "reweight": 1 }
+	  ]
+	}
+`
+	runOsdTree = func() (string, error) { return osdTreeOut, nil }
+
+	require.ElementsMatch(t, mustGetOsdsForBucket("rack1", "red"),
+		[]int{1, 4, 7, 10})
+	require.ElementsMatch(t, mustGetOsdsForBucket("rack1", "blue"),
+		[]int{2, 6, 8, 11})
+	require.ElementsMatch(t, mustGetOsdsForBucket("host1", "green"),
+		[]int{0})
+	require.ElementsMatch(t, mustGetOsdsForBucket("host4", ""),
+		[]int{9, 10, 11})
+}
+
 func teardownTest(t *testing.T) {
 	savedOsdDumpOut = nil
 	savedParsedOsdTree = nil


### PR DESCRIPTION
Added device-class filter for support balancing buckets contains multiple device-classes, should resolves #19 

Balance rack without device class:

<img width="870" alt="image" src="https://user-images.githubusercontent.com/7759548/151659715-4f935c4b-d5b8-4376-adb8-f9c8d1dfdaec.png">

Balance rack with device class:

<img width="931" alt="image" src="https://user-images.githubusercontent.com/7759548/151659745-7ed67852-911d-484b-b70f-f2bc52404b44.png">

Balance rack with another device class:

<img width="938" alt="image" src="https://user-images.githubusercontent.com/7759548/151659752-c19a8176-03c3-4625-80b0-f9d948aeb2c0.png">

Test `TestDeviceClassFilter` added also