### PR TITLE
ceph: Don't panic when multiple complete shards are found for an EC PG.

### DIFF
--- a/ceph.go
+++ b/ceph.go
@@ -170,7 +170,12 @@ func (pqo *pgQueryOut) getCompletePeers() []int {
 				continue
 			}
 			if peers[index] != invalidOSD {
-				panic(fmt.Sprintf("%s: multiple complete shards at index %d", pqo.Info.PgID, index))
+				// This almost certainly means that a backfill
+				// completed and the stale shard hasn't been
+				// cleaned up yet, but we haven't been able to
+				// observe a PG query from this case yet.
+				fmt.Printf("WARNING: PG %s has multiple complete shards at index %d - current acting or first queried chosen as upmap target", pqo.Info.PgID, index)
+				continue
 			}
 			peers[index] = osd
 		} else {


### PR DESCRIPTION
This addresses the panic in https://github.com/digitalocean/pgremapper/issues/27.