### PR TITLE
Use the newest shard when there multiple shards are at the index

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -92,11 +92,12 @@ func TestCalcPgMappingsToUndoBackfill(t *testing.T) {
   "acting": [ 33, 37, 2147483647 ],
   "info": { "pgid": "1.91" },
   "peer_info": [
-    { "peer": "37(1)", "incomplete": 0 },
-    { "peer": "36(1)", "incomplete": 1 },
-    { "peer": "33(0)", "incomplete": 0 },
-    { "peer": "30(2)", "incomplete": 1 },
-    { "peer": "38(2)", "incomplete": 0 }
+    { "peer": "37(1)", "incomplete": 0, "stats": {"last_epoch_clean": 101} },
+    { "peer": "36(1)", "incomplete": 1, "stats": {"last_epoch_clean": 100} },
+    { "peer": "33(0)", "incomplete": 0, "stats": {"last_epoch_clean": 100} },
+    { "peer": "30(2)", "incomplete": 1, "stats": {"last_epoch_clean": 100} },
+    { "peer": "38(2)", "incomplete": 0, "stats": {"last_epoch_clean": 101} },
+    { "peer": "39(2)", "incomplete": 0, "stats": {"last_epoch_clean": 99} }
   ]
 }
 		    `, nil


### PR DESCRIPTION
For EC peers the incomplete field does not work at identifying which OSD to choose. The last_epoch_clean field is now used to select which OSD.