### PR TITLE
add generate-crush-change-mappings command

### DIFF
--- a/ceph.go
+++ b/ceph.go
@@ -648,7 +648,7 @@ func parseCrushDiff(in string) ([]*pgUpmapItem, error) {
 	for sc.Scan() {
 		line := strings.TrimSpace(sc.Text())
 
-		// For PGs that are part of a 3x replicated pool, each
+		// For PGs that are part of, for instance, a 3x replicated pool, each
 		// line mapping should look something like follows:
 		//
 		//  1.0	[3, 7, 8] -> [3, 7, 2]

--- a/ceph_test.go
+++ b/ceph_test.go
@@ -1,0 +1,162 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseCrushDiff(t *testing.T) {
+	for _, tt := range []struct {
+		name    string
+		crushIn string
+		items   []pgMapping
+		errMsg  string
+	}{
+		{
+			name: "valid case with 2 PGs remapped",
+			crushIn: `
+#osd	count	first	primary	c wt	wt
+osd.0	79	30	30	0.00979614	1
+osd.1	84	28	28	0.00979614	1
+osd.2	57	20	20	0.00979614	1
+osd.3	51	22	22	0.00979614	1
+osd.4	50	13	13	0.00979614	1
+osd.5	50	18	18	0.00979614	1
+osd.6	54	18	18	0.00979614	1
+osd.7	52	15	15	0.00979614	1
+osd.8	54	13	13	0.00979614	1
+ in 9
+ avg 59 stddev 12.2656 (0.207891x) (expected 7.24185 0.122743x))
+ min osd.4 50
+ max osd.1 84
+size 3	177
+osdmaptool: writing epoch 847 to /tmp/tmp5ip_axby/osdmap
+osdmaptool /tmp/tmp5ip_axby/osdmap --dump json > /tmp/tmp5ip_axby/osdmap.json
+osdmaptool: osdmap file '/tmp/tmp5ip_axby/osdmap'
+1.0	[3, 7, 8] -> [3, 7, 2]
+2.0	[4, 5, 8] -> [3, 6, 0]
+		`,
+			items: []pgMapping{
+				{
+					PgID:    "1.0",
+					Mapping: mapping{From: 8, To: 2},
+				},
+				{
+					PgID:    "2.0",
+					Mapping: mapping{From: 4, To: 3},
+				},
+				{
+					PgID:    "2.0",
+					Mapping: mapping{From: 5, To: 6},
+				},
+				{
+					PgID:    "2.0",
+					Mapping: mapping{From: 8, To: 0},
+				},
+			},
+			errMsg: "",
+		},
+		{
+			name: "invalid case with 1 PG with mismatched To set",
+			crushIn: `
+#osd	count	first	primary	c wt	wt
+osd.0	79	30	30	0.00979614	1
+osd.1	84	28	28	0.00979614	1
+osd.2	57	20	20	0.00979614	1
+osd.3	51	22	22	0.00979614	1
+osd.4	50	13	13	0.00979614	1
+osd.5	50	18	18	0.00979614	1
+osd.6	54	18	18	0.00979614	1
+osd.7	52	15	15	0.00979614	1
+osd.8	54	13	13	0.00979614	1
+ in 9
+ avg 59 stddev 12.2656 (0.207891x) (expected 7.24185 0.122743x))
+ min osd.4 50
+ max osd.1 84
+size 3	177
+osdmaptool: writing epoch 847 to /tmp/tmp5ip_axby/osdmap
+osdmaptool /tmp/tmp5ip_axby/osdmap --dump json > /tmp/tmp5ip_axby/osdmap.json
+osdmaptool: osdmap file '/tmp/tmp5ip_axby/osdmap'
+1.0	[3, 7, 8] -> [3, 7, 2]
+2.0	[4, 5, 8] -> [3, 6]
+		`,
+			items:  nil,
+			errMsg: "could not parse PG mapping entry: invalid PG mapping entry",
+		},
+		{
+			name: "invalid case with 1 PG with mismatched From set",
+			crushIn: `
+#osd	count	first	primary	c wt	wt
+osd.0	79	30	30	0.00979614	1
+osd.1	84	28	28	0.00979614	1
+osd.2	57	20	20	0.00979614	1
+osd.3	51	22	22	0.00979614	1
+osd.4	50	13	13	0.00979614	1
+osd.5	50	18	18	0.00979614	1
+osd.6	54	18	18	0.00979614	1
+osd.7	52	15	15	0.00979614	1
+osd.8	54	13	13	0.00979614	1
+ in 9
+ avg 59 stddev 12.2656 (0.207891x) (expected 7.24185 0.122743x))
+ min osd.4 50
+ max osd.1 84
+size 3	177
+osdmaptool: writing epoch 847 to /tmp/tmp5ip_axby/osdmap
+osdmaptool /tmp/tmp5ip_axby/osdmap --dump json > /tmp/tmp5ip_axby/osdmap.json
+osdmaptool: osdmap file '/tmp/tmp5ip_axby/osdmap'
+1.0	[3, 7, 8] -> [3, 7, 2]
+2.0	[4, 5] -> [3, 6, 0]
+		`,
+			items:  nil,
+			errMsg: "could not parse PG mapping entry: invalid PG mapping entry",
+		},
+		{
+			name: "invalid case with 1 PG with both mismatched sets",
+			crushIn: `
+#osd	count	first	primary	c wt	wt
+osd.0	79	30	30	0.00979614	1
+osd.1	84	28	28	0.00979614	1
+osd.2	57	20	20	0.00979614	1
+osd.3	51	22	22	0.00979614	1
+osd.4	50	13	13	0.00979614	1
+osd.5	50	18	18	0.00979614	1
+osd.6	54	18	18	0.00979614	1
+osd.7	52	15	15	0.00979614	1
+osd.8	54	13	13	0.00979614	1
+ in 9
+ avg 59 stddev 12.2656 (0.207891x) (expected 7.24185 0.122743x))
+ min osd.4 50
+ max osd.1 84
+size 3	177
+osdmaptool: writing epoch 847 to /tmp/tmp5ip_axby/osdmap
+osdmaptool /tmp/tmp5ip_axby/osdmap --dump json > /tmp/tmp5ip_axby/osdmap.json
+osdmaptool: osdmap file '/tmp/tmp5ip_axby/osdmap'
+1.0	[3, 7, 8] -> [3, 7, 2]
+2.0	[4] -> [3, 6, 0]
+		`,
+			items:  nil,
+			errMsg: "could not parse PG mapping entry: unequal count between existing and new OSD sets within mapping",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			runCrushCmp = func(_ string) (string, error) {
+				return tt.crushIn, nil
+			}
+			if tt.errMsg != "" {
+				defer func() {
+					msg := recover()
+					require.NotNil(t, msg)
+
+					e, ok := msg.(error)
+					require.True(t, ok)
+					require.Contains(t, e.Error(), tt.errMsg)
+				}()
+			}
+
+			items, err := crushCmp("")
+			require.Nil(t, err)
+			require.Equal(t, items, tt.items)
+		})
+	}
+}

--- a/ceph_test.go
+++ b/ceph_test.go
@@ -1,3 +1,17 @@
+// Copyright 2021 DigitalOcean
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package main
 
 import (

--- a/main.go
+++ b/main.go
@@ -350,8 +350,8 @@ mapping), unless --whole-pg is specified.
 		},
 	}
 
-	exportCrushMappingsCommand = &cobra.Command{
-		Use:   "export-crush-change-mappings",
+	generateCrushMappingsCommand = &cobra.Command{
+		Use:   "generate-crush-change-mappings",
 		Short: "Export the mappings incurred from making a CRUSHmap change.",
 		Long: `Export the mappings incurred from making a CRUSHmap change.
 
@@ -645,9 +645,9 @@ func init() {
 	exportMappingsCommand.Flags().Bool("whole-pg", false, "export all mappings for any PGs that include the given OSD(s), not just the portions pertaining to those OSDs")
 	rootCmd.AddCommand(exportMappingsCommand)
 
-	exportCrushMappingsCommand.Flags().String("crushmap-text", "", "CRUSHmap, with changes, provided in the text format")
-	exportCrushMappingsCommand.Flags().String("output", "", "write output to the given file path instead of stdout")
-	rootCmd.AddCommand(exportCrushMappingsCommand)
+	generateCrushMappingsCommand.Flags().String("crushmap-text", "", "CRUSHmap, with changes, provided in the text format")
+	generateCrushMappingsCommand.Flags().String("output", "", "write output to the given file path instead of stdout")
+	rootCmd.AddCommand(generateCrushMappingsCommand)
 
 	rootCmd.AddCommand(importMappingsCommand)
 

--- a/main.go
+++ b/main.go
@@ -350,6 +350,52 @@ mapping), unless --whole-pg is specified.
 		},
 	}
 
+	exportCrushMappingsCommand = &cobra.Command{
+		Use:   "export-crush-change-mappings",
+		Short: "Export the mappings incurred from making a CRUSHmap change.",
+		Long: `Export the mappings incurred from making a CRUSHmap change.
+
+Export all upmaps for a given CRUSHmap change in a json format usable by
+import-mappings. Useful for keeping the state of existing mappings to restore
+after destroying a number of OSDs, or any other CRUSH change that will cause
+upmap items to be cleaned up by the mons.
+
+A typical use-case could be changing a given CRUSH rule to switch chooseleaf
+from "osd" to "host", or from "host" to "rack". Once this new CRUSHmap is
+injected into the existing OSDMap, a large number of PGs will be subject to
+backfill -- that cannot be cancelled. Using this subcommand, we can pregenerate
+a list of upmap mappings, that we can gradually import, in order to move PGs
+such that they are already conform to the expected spread. Injecting a new
+CRUSHmap after this process completes, should largely be a no-op (unless the
+cluster undergoes some other major changes).
+`,
+		Run: func(cmd *cobra.Command, args []string) {
+			var writer io.Writer
+			cm := mustGetString(cmd, "crushmap-text")
+			output := mustGetString(cmd, "output")
+			if output == "" {
+				writer = os.Stdout
+			} else {
+				f, err := os.Create(output)
+				if err != nil {
+					panic(err)
+				}
+				defer f.Close()
+
+				writer = f
+			}
+
+			mappings, err := crushCmp(cm)
+			if err != nil {
+				panic(err)
+			}
+
+			if err := json.NewEncoder(writer).Encode(mappings); err != nil {
+				panic(err)
+			}
+		},
+	}
+
 	importMappingsCommand = &cobra.Command{
 		Use:   "import-mappings [<file>]",
 		Short: "Import and apply mappings.",
@@ -598,6 +644,11 @@ func init() {
 	exportMappingsCommand.Flags().String("output", "", "write output to the given file path instead of stdout")
 	exportMappingsCommand.Flags().Bool("whole-pg", false, "export all mappings for any PGs that include the given OSD(s), not just the portions pertaining to those OSDs")
 	rootCmd.AddCommand(exportMappingsCommand)
+
+	exportCrushMappingsCommand.Flags().String("crushmap-text", "", "CRUSHmap, with changes, provided in the text format")
+	exportCrushMappingsCommand.Flags().String("output", "", "write output to the given file path instead of stdout")
+	rootCmd.AddCommand(exportCrushMappingsCommand)
+
 	rootCmd.AddCommand(importMappingsCommand)
 
 	rootCmd.AddCommand(versionCmd)
@@ -1002,6 +1053,22 @@ func run(command ...string) (string, error) {
 	}
 
 	return string(stdout), nil
+}
+
+func runCombined(command ...string) (string, error) {
+	if verbose {
+		fmt.Fprintf(os.Stderr, "** executing: %s\n", strings.Join(command, " "))
+	}
+
+	cmd := exec.Command(command[0], command[1:]...)
+	out, err := cmd.CombinedOutput()
+
+	if err != nil {
+		return "", errors.Wrapf(err, "failed to execute command: %q",
+			strings.Join(command, " "))
+	}
+
+	return string(out), nil
 }
 
 func runOrDie(command ...string) string {


### PR DESCRIPTION
This change adds a new `generate-crush-change-mappings` command to pgremapper. It attempts to address use-cases that require us to perform a major change on the CRUSHmap that can potentially incur a large rebalance of PGs across OSDs or hosts (or more). Using this command, we can now generate a list of new upmap mappings  that we can gradually (or completely) import to perform the rebalance in advance before actually injecting the change via CRUSHmap.

An example use-case is to change the chooseleaf of a CRUSH rule to `host` from `osd` or to `rack` from `host`. This change can potentially incur a significant amount of backfills that cannot be easily cancelled since cancelling it would violate the new spread constraint set via the change to the crush rule. Using this command, we should be able to simulate and export a new set of mappings that can be applied in advance, prior to injecting the new CRUSHmap into the OSDMap.

Changes remaining before merging PR:
- [x] Write tests to cover newly added functions.
- [x] Update README to describe the usage.