### PR TITLE
pgremapper drain: support draining from multiple sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,10 +180,10 @@ Export all upmaps for the given OSD spec(s) in a json format usable by import-ma
 Note that the mappings exported will be just the portions of the upmap items pertaining to the selected OSDs (i.e. if a given OSD is the From or To of the mapping), unless `--whole-pg` is specified.
 
 ```
-$ ./pgremapper export-mappings <osdspec> ... [--output <file>] [--whole-pg]
+$ ./pgremapper export-mappings <osdspec> [<osdspec> ...] [--output <file>] [--whole-pg]
 ```
 
-* `<osdspec> ...`: The OSDs for which mappings will be exported.
+* `<osdspec> ...`: The OSDs (or OSD specs) for which mappings will be exported.
 * `--output`: Write output to the given file path instead of `stdout`.
 * `--whole-pg`: Export all mappings for any PGs that include the given OSD(s), not just the portions pertaining to those OSDs.
 

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ Remap PGs off of the given source OSD spec(s), up to the given maximum number of
 If a source OSD is included among target OSDs, it will be removed from the targets.
 
 ```
-$ ./pgremapper drain <osdspec>[,<osdspec>] --target-osds <osdspec>[,<osdspec>] [--allow-movement-across <bucket type>] [--max-backfill-reservations default_max[,osdspec:max]] [--max-source-backfills <n>]
+$ ./pgremapper drain <osdspec> [<osdspec> ...] --target-osds <osdspec>[,<osdspec>] [--allow-movement-across <bucket type>] [--max-backfill-reservations default_max[,osdspec:max]] [--max-source-backfills <n>]
 ```
 
 * `<source OSD>`: The OSD that will become the backfill source.
@@ -254,7 +254,7 @@ Given a list of OSDs, remove (or modify) upmap items such that the OSDs become t
 This is useful for cases where the upmap rebalancer won't do this for us, e.g., performing a swap-bucket where we want the source OSDs to totally drain (vs. balance with the rest of the cluster). It also achieves a much higher level of concurrency than the balancer generally will.
 
 ```
-$ ./pgremapper undo-upmaps <osdspec>[,<osdspec>] [--max-backfill-reservations default_max[,osdspec:max]] [--max-source-backfills <n>] [--target]
+$ ./pgremapper undo-upmaps <osdspec> [<osdspec> ...] [--max-backfill-reservations default_max[,osdspec:max]] [--max-source-backfills <n>] [--target]
 ```
 
 * `--max-backfill-reservations`: Consume only the given reservation maximums for backfill. You'll commonly want to set this below your `osd-max-backfills` setting so that any scheduled recoveries may clear without waiting for a backfill to complete. A default value is specified first, and then per-`osdspec` values for cases where you want to allow more backfill or have non-uniform `osd-max-backfills` settings.

--- a/README.md
+++ b/README.md
@@ -146,10 +146,11 @@ $ ./pgremapper cancel-backfill --pgs-including bucket:data10
 
 ### drain
 
-Remap PGs off of the given source OSD, up to the given maximum number of scheduled backfills. No attempt is made to balance the fullness of the target OSDs; rather, the least busy target OSDs and PGs will be selected.
+Remap PGs off of the given source OSD spec(s), up to the given maximum number of scheduled backfills. No attempt is made to balance the fullness of the target OSDs; rather, the least busy target OSDs and PGs will be selected.
+If a source OSD is included among target OSDs, it will be removed from the targets.
 
 ```
-$ ./pgremapper drain <source OSD> --target-osds <osdspec>[,<osdspec>] [--allow-movement-across <bucket type>] [--max-backfill-reservations default_max[,osdspec:max]] [--max-source-backfills <n>]
+$ ./pgremapper drain <osdspec>[,<osdspec>] --target-osds <osdspec>[,<osdspec>] [--allow-movement-across <bucket type>] [--max-backfill-reservations default_max[,osdspec:max]] [--max-source-backfills <n>]
 ```
 
 * `<source OSD>`: The OSD that will become the backfill source.

--- a/go.sum
+++ b/go.sum
@@ -240,7 +240,6 @@ golang.org/x/sys v0.0.0-20190507160741-ecd444e8653b/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20190606165138-5da285871e9c/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190624142023-c5567b49c5d0/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200116001909-b77594299b42/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20200223170610-d5e6a3e2c0ae h1:/WDfKMnPU+m5M4xB+6x4kaepxRw6jWvR5iDRdvjHgy8=
 golang.org/x/sys v0.0.0-20200223170610-d5e6a3e2c0ae/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20220412211240-33da011f77ad h1:ntjMns5wyP/fN65tdBD4g8J5w8n015+iIIs9rtjXkY0=
 golang.org/x/sys v0.0.0-20220412211240-33da011f77ad/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/main.go
+++ b/main.go
@@ -143,7 +143,7 @@ has been made so far.
 	}
 
 	drainCmd = &cobra.Command{
-		Use:   "drain <source osdspec>",
+		Use:   "drain [<osdspec> ...]",
 		Short: "Drain PGs from one or more source OSDs to the target OSDs.",
 		Long: `Drain PGs from one or more source OSDs to the target OSDs.
 
@@ -208,7 +208,7 @@ OSDs; rather, the least busy target OSDs and PGs will be selected.
 	}
 
 	undoUpmapsCmd = &cobra.Command{
-		Use:   "undo-upmaps [osd IDs...]",
+		Use:   "undo-upmaps <osdspec> [<osdspec> ...]",
 		Short: "Undo upmap entries for the given source/target OSDs",
 		Long: `Undo upmap entries for the given source/target OSDs.
 

--- a/main.go
+++ b/main.go
@@ -143,7 +143,7 @@ has been made so far.
 	}
 
 	drainCmd = &cobra.Command{
-		Use:   "drain [<osdspec> ...]",
+		Use:   "drain <osdspec> [<osdspec> ...]",
 		Short: "Drain PGs from one or more source OSDs to the target OSDs.",
 		Long: `Drain PGs from one or more source OSDs to the target OSDs.
 
@@ -153,7 +153,7 @@ OSDs; rather, the least busy target OSDs and PGs will be selected.
 `,
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) == 0 {
-				return errors.New("a source OSD must be specified")
+				return errors.New("one or more source OSDs must be specified")
 			}
 
 			for _, arg := range args {

--- a/main.go
+++ b/main.go
@@ -173,7 +173,7 @@ OSDs; rather, the least busy target OSDs and PGs will be selected.
 			targetOsds := mustGetOsdSpecSliceMap(cmd, "target-osds")
 			tree := osdTree()
 
-			for targetOsd, _ := range targetOsds {
+			for targetOsd := range targetOsds {
 				targetOsdNode, ok := tree.IDToNode[targetOsd]
 				if !ok || targetOsdNode.Type != "osd" {
 					panic(fmt.Errorf("target OSD %d doesn't exist", targetOsd))

--- a/main.go
+++ b/main.go
@@ -152,7 +152,7 @@ scheduled backfills. No attempt is made to balance the fullness of the target
 OSDs; rather, the least busy target OSDs and PGs will be selected.
 `,
 		Args: func(cmd *cobra.Command, args []string) error {
-			if len(args) != 1 {
+			if len(args) == 0 {
 				return errors.New("a source OSD must be specified")
 			}
 

--- a/main_test.go
+++ b/main_test.go
@@ -835,13 +835,21 @@ func TestCalcPgMappingsToDrainOsd(t *testing.T) {
 			M.bs.maxBackfillsFrom = maxSourceBackfills
 			calcPgMappingsToDrainOsd(
 				tt.allowMovementAcrossCrushType,
-				sourceOsd,
-				tt.targetOsds,
+				[]int{sourceOsd},
+				sliceToMap(tt.targetOsds),
 			)
 
 			validateDirtyMappings(t, tt.expected)
 		})
 	}
+}
+
+func sliceToMap(slice []int) map[int]struct{} {
+	ret := make(map[int]struct{}, len(slice))
+	for _, item := range slice {
+		ret[item] = struct{}{}
+	}
+	return ret
 }
 
 type expectedMapping struct {


### PR DESCRIPTION
Allows you to specify multiple OSDs, or an entire osdspec as your source for the 'drain' sub-command. 
