### PR TITLE
pgremapper: Add missing return to accountForRemap().

### DIFF
--- a/backfillstate.go
+++ b/backfillstate.go
@@ -87,6 +87,7 @@ func (bs *backfillState) accountForRemap(pgid string, from, to int) {
 			// acting by themselves.
 			reorderUpToMatchActing(pgid, pgb.Up, pgb.Acting, false)
 			bs.addReservations(pgb)
+			return
 		}
 	}
 	// We can get here if a remap has been requested where the 'from' OSD


### PR DESCRIPTION
When a previous commit refactored this function, this return was missed.