### PR TITLE
pgremapper: Update Copyright year to 2026

### DIFF
--- a/backfillstate.go
+++ b/backfillstate.go
@@ -1,4 +1,4 @@
-// Copyright 2021 DigitalOcean
+// Copyright 2026 DigitalOcean
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/backfillstate_test.go
+++ b/backfillstate_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021 DigitalOcean
+// Copyright 2026 DigitalOcean
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/ceph.go
+++ b/ceph.go
@@ -1,4 +1,4 @@
-// Copyright 2021 DigitalOcean
+// Copyright 2026 DigitalOcean
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/ceph_test.go
+++ b/ceph_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021 DigitalOcean
+// Copyright 2026 DigitalOcean
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/main.go
+++ b/main.go
@@ -1,4 +1,4 @@
-// Copyright 2021 DigitalOcean
+// Copyright 2026 DigitalOcean
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/main_test.go
+++ b/main_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021 DigitalOcean
+// Copyright 2026 DigitalOcean
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/mappingstate.go
+++ b/mappingstate.go
@@ -1,4 +1,4 @@
-// Copyright 2021 DigitalOcean
+// Copyright 2026 DigitalOcean
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/mappingstate_test.go
+++ b/mappingstate_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021 DigitalOcean
+// Copyright 2026 DigitalOcean
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/panic.go
+++ b/panic.go
@@ -1,4 +1,4 @@
-// Copyright 2021 DigitalOcean
+// Copyright 2026 DigitalOcean
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.


### PR DESCRIPTION
Dependent upon https://github.com/digitalocean/pgremapper/pull/63.