### PR TITLE
feat: Add benchmarking and significantly refactor based on results

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,10 +46,139 @@ go install github.com/digitalocean/pgremapper@latest
 
 Otherwise, clone this repository and use a golang Docker container to build:
 ```
-docker run --rm -v $(pwd):/pgremapper -w /pgremapper golang:1.21.4 go build -o pgremapper .
+docker run --rm -v $(pwd):/pgremapper -w /pgremapper golang:1.26.2 go build -o pgremapper .
 ```
 
 You can also download one of the pre-built binaries from the [releases page](https://github.com/digitalocean/pgremapper/releases).
+
+## Performance Profiling
+
+This repository includes benchmark scaffolding in `benchmark_test.go` so you can profile parsing and remap decision paths without a live Ceph cluster.
+
+### 1) Run benchmarks
+
+Run all benchmarks using Go's default benchtime:
+
+```
+go test -run '^$' -bench=. -benchmem ./...
+```
+
+Run all benchmarks with a fixed time budget per benchmark, saving results to a file:
+
+```
+go test -run '^$' -bench=. -benchtime=60s -benchmem ./... | tee bench-results.txt
+```
+
+Run a specific benchmark family only:
+
+```
+go test -run '^$' -bench='^BenchmarkCalc' -benchtime=60s -benchmem ./...
+```
+
+`-bench=.` matches every benchmark function. `-benchmem` adds `B/op` and `allocs/op` columns.
+
+Benchmark fixture profiles used in `benchmark_test.go`:
+
+* `small`: `pgCount=4096`, `osdCount=128`, and for upmap-heavy cases `upmapCount=300`.
+* `medium`: `pgCount=16384`, `osdCount=512`, and for upmap-heavy cases `upmapCount=1200`.
+* `large`: `pgCount=65536`, `osdCount=2048`, and for upmap-heavy cases `upmapCount=4800`.
+
+Notes:
+
+* All benchmark families include `small`, `medium`, and `large` sub-benchmarks.
+* `-benchtime=60s` applies per benchmark/sub-benchmark that is selected (for example, `.../small` or `.../medium`).
+* Benchmark setup is included in timed sections, so wall-clock runtime more closely tracks the benchtime target.
+* Use `-benchtime=1x` when you want exactly one iteration for quick smoke checks.
+
+### 2) Capture CPU, heap, mutex, and block profiles
+
+```
+go test -run '^$' -bench BenchmarkMustGetCurrentMappingState/large -benchmem \
+  -cpuprofile cpu.out -memprofile mem.out ./...
+```
+
+You can swap the benchmark selector for any benchmark/sub-benchmark, for example:
+
+```
+go test -run '^$' -bench BenchmarkCalcPgMappingsToUndoBackfill/medium -benchmem \
+  -cpuprofile cpu.out -memprofile mem.out ./...
+```
+
+To include mutex and block contention profiles in the same run:
+
+```
+go test -run '^$' -bench BenchmarkCalcPgMappingsToUndoBackfill/medium -benchmem \
+  -cpuprofile cpu.out -memprofile mem.out \
+  -mutexprofile mutex.out -blockprofile block.out ./...
+```
+
+Notes for contention profiles:
+
+* `-mutexprofile` captures time spent waiting on contended mutexes.
+* `-blockprofile` captures goroutine blocking events (channel ops, selects, mutex waits, etc.).
+* In benchmark-wide runs, block profiles often contain significant `testing` harness channel waits; prefer targeted benchmark selectors when investigating an individual code path.
+* If needed, you can tune sampling rates in code via `runtime.SetMutexProfileFraction` and `runtime.SetBlockProfileRate`, but defaults are often sufficient for comparative benchmark runs.
+
+### 3) Inspect profiles with pprof
+
+CPU profile:
+
+```
+go tool pprof -top cpu.out
+```
+
+Heap allocation profile:
+
+```
+go tool pprof -top -alloc_space mem.out
+```
+
+Mutex contention profile (delay view):
+
+```
+go tool pprof -top mutex.out
+```
+
+Block profile (delay view):
+
+```
+go tool pprof -top block.out
+```
+
+Contention/event count views:
+
+```
+go tool pprof -top -sample_index=contentions mutex.out
+go tool pprof -top -sample_index=contentions block.out
+```
+
+To open an interactive web UI:
+
+```
+go tool pprof -http=:8080 cpu.out
+```
+
+Then open `http://localhost:8080` in a browser.
+
+### 4) Useful pprof commands inside interactive mode
+
+If you run `go tool pprof <profile.out>`, these commands are useful:
+
+* `top` - hottest functions by self time
+* `top -cum` - hottest functions by cumulative time
+* `list <function>` - annotated source for a function
+* `web` - render the call graph (requires Graphviz installed)
+
+### 5) Repeatability tips
+
+* Run each benchmark at least 3 times and compare medians.
+* If results are noisy, increase benchmark time:
+
+```
+go test -run '^$' -bench BenchmarkMustGetCurrentMappingState/large -benchmem -benchtime=60s ./...
+```
+
+* Keep your machine load low and avoid running other heavy workloads while profiling.
 
 ## Usage
 

--- a/backfillstate.go
+++ b/backfillstate.go
@@ -108,8 +108,8 @@ func (bs *backfillState) accountForRemap(pgid string, from, to int) {
 }
 
 func (bs *backfillState) addReservations(pgb *pgBriefItem) {
-	var srcBuf [8]int
-	var tgtBuf [8]int
+	srcBuf := make([]int, 0, len(pgb.Acting))
+	tgtBuf := make([]int, 0, len(pgb.Acting))
 	srcs, tgts := computeBackfillSrcsTgts(pgb, srcBuf[:0], tgtBuf[:0])
 	for _, osd := range srcs {
 		bs.osd(osd).backfillsFrom++
@@ -123,8 +123,8 @@ func (bs *backfillState) addReservations(pgb *pgBriefItem) {
 }
 
 func (bs *backfillState) removeReservations(pgb *pgBriefItem) {
-	var srcBuf [8]int
-	var tgtBuf [8]int
+	srcBuf := make([]int, 0, len(pgb.Acting))
+	tgtBuf := make([]int, 0, len(pgb.Acting))
 	srcs, tgts := computeBackfillSrcsTgts(pgb, srcBuf[:0], tgtBuf[:0])
 	for _, osd := range srcs {
 		obs := bs.osd(osd)

--- a/backfillstate.go
+++ b/backfillstate.go
@@ -40,8 +40,9 @@ type osdBackfillState struct {
 }
 
 type backfillState struct {
-	osds map[int]*osdBackfillState
-	pgbs map[string]*pgBriefItem
+	osds     map[int]*osdBackfillState
+	pgbs     map[string]*pgBriefItem
+	pgCounts map[int]int
 
 	maxBackfillsFrom int
 	// The configured default max backfill reservations when not specified
@@ -56,14 +57,22 @@ func mustGetCurrentBackfillState() *backfillState {
 	for _, pgb := range pgBriefs {
 		bs.pgbs[pgb.PgID] = pgb
 		bs.addReservations(pgb)
+		for _, osd := range pgb.Up {
+			bs.pgCounts[osd]++
+			bs.osd(osd)
+		}
+		for _, osd := range pgb.Acting {
+			bs.osd(osd)
+		}
 	}
 	return bs
 }
 
 func makeBackfillState() *backfillState {
 	return &backfillState{
-		osds: make(map[int]*osdBackfillState),
-		pgbs: make(map[string]*pgBriefItem),
+		osds:     make(map[int]*osdBackfillState),
+		pgbs:     make(map[string]*pgBriefItem),
+		pgCounts: make(map[int]int),
 
 		maxBackfillsFrom:        math.MaxInt32,
 		maxBackfillReservations: math.MaxInt32,
@@ -82,6 +91,8 @@ func (bs *backfillState) accountForRemap(pgid string, from, to int) {
 		if osd == from {
 			bs.removeReservations(pgb)
 			pgb.Up[i] = to
+			bs.pgCounts[from]--
+			bs.pgCounts[to]++
 			// Do not use the upmap here as we don't need to strictly re-order the
 			// up set; it's sufficient to consider which OSDs are listed in up and
 			// acting by themselves.
@@ -97,7 +108,9 @@ func (bs *backfillState) accountForRemap(pgid string, from, to int) {
 }
 
 func (bs *backfillState) addReservations(pgb *pgBriefItem) {
-	srcs, tgts := computeBackfillSrcsTgts(pgb)
+	var srcBuf [8]int
+	var tgtBuf [8]int
+	srcs, tgts := computeBackfillSrcsTgts(pgb, srcBuf[:0], tgtBuf[:0])
 	for _, osd := range srcs {
 		bs.osd(osd).backfillsFrom++
 	}
@@ -110,7 +123,9 @@ func (bs *backfillState) addReservations(pgb *pgBriefItem) {
 }
 
 func (bs *backfillState) removeReservations(pgb *pgBriefItem) {
-	srcs, tgts := computeBackfillSrcsTgts(pgb)
+	var srcBuf [8]int
+	var tgtBuf [8]int
+	srcs, tgts := computeBackfillSrcsTgts(pgb, srcBuf[:0], tgtBuf[:0])
 	for _, osd := range srcs {
 		obs := bs.osd(osd)
 		if obs.backfillsFrom == 0 {
@@ -166,9 +181,12 @@ func (bs *backfillState) hasRoomForRemap(pgid string, from, to int) bool {
 		hasRoom = false
 	}
 
-	_, tgts := computeBackfillSrcsTgts(pgb)
-	for _, osd := range tgts {
-		if bs.osd(osd).remoteReservations > bs.getMaxBackfillReservations(osd) {
+	// Avoid transient target-slice allocation in this hot check path.
+	for i := range pgb.Acting {
+		if pgb.Up[i] == pgb.Acting[i] {
+			continue
+		}
+		if bs.osd(pgb.Up[i]).remoteReservations > bs.getMaxBackfillReservations(pgb.Up[i]) {
 			hasRoom = false
 		}
 	}
@@ -185,20 +203,16 @@ func (bs *backfillState) getMaxBackfillReservations(osd int) int {
 	return bs.maxBackfillReservations
 }
 
-// pgCountsByOsd returns how many PGs list each OSD in their up set (live bs.pgbs).
+// pgCountsByOsd returns how many PGs list each OSD in their up set.
+// The returned map is the live backing store; callers must not mutate it.
 func (bs *backfillState) pgCountsByOsd() map[int]int {
-	counts := make(map[int]int)
-	for _, pgb := range bs.pgbs {
-		for _, osd := range pgb.Up {
-			counts[osd]++
-		}
-	}
-	return counts
+	return bs.pgCounts
 }
 
-func computeBackfillSrcsTgts(pgb *pgBriefItem) ([]int, []int) {
-	srcs := []int{}
-	tgts := []int{}
+func computeBackfillSrcsTgts(pgb *pgBriefItem, srcs, tgts []int) ([]int, []int) {
+	// Reuse caller-provided buffers when possible to avoid per-call allocations.
+	srcs = srcs[:0]
+	tgts = tgts[:0]
 	up := pgb.Up
 	acting := pgb.Acting
 

--- a/backfillstate_test.go
+++ b/backfillstate_test.go
@@ -238,8 +238,8 @@ func TestComputeBackfillSrcsTgts(t *testing.T) {
 			Acting: []int{1, 22, 3, 4, 5, 66},
 		}
 
-		var srcBuf [8]int
-		var tgtBuf [8]int
+		srcBuf := make([]int, 0, len(pgb.Acting))
+		tgtBuf := make([]int, 0, len(pgb.Acting))
 		srcs, tgts := computeBackfillSrcsTgts(pgb, srcBuf[:0], tgtBuf[:0])
 
 		require.Equal(t, []int{22, 3, 5, 66}, srcs)
@@ -253,8 +253,8 @@ func TestComputeBackfillSrcsTgts(t *testing.T) {
 			Acting: []int{1, 2, 3},
 		}
 
-		var srcBuf [8]int
-		var tgtBuf [8]int
+		srcBuf := make([]int, 0, len(pgb.Acting))
+		tgtBuf := make([]int, 0, len(pgb.Acting))
 		srcs, tgts := computeBackfillSrcsTgts(pgb, srcBuf[:0], tgtBuf[:0])
 
 		require.Empty(t, srcs)
@@ -274,8 +274,8 @@ func TestComputeBackfillSrcsTgts(t *testing.T) {
 		}
 		pgb := &pgBriefItem{PgID: "1.4", Up: up, Acting: acting}
 
-		var srcBuf [8]int
-		var tgtBuf [8]int
+		srcBuf := make([]int, 0, len(pgb.Acting))
+		tgtBuf := make([]int, 0, len(pgb.Acting))
 		srcs, tgts := computeBackfillSrcsTgts(pgb, srcBuf[:0], tgtBuf[:0])
 
 		require.Equal(t, expectSrc, srcs)

--- a/backfillstate_test.go
+++ b/backfillstate_test.go
@@ -22,7 +22,7 @@ import (
 
 func TestBackfillState(t *testing.T) {
 	setupTest(t)
-	defer teardownTest(t)
+	t.Cleanup(func() { teardownTest(t) })
 	pgDumpOut := `
 [
  { "pgid": "1.01", "up": [ 77, 1, 2 ], "acting": [ 77, 1, 2 ] },
@@ -106,7 +106,7 @@ func TestBackfillState(t *testing.T) {
 
 func TestPgCountsByOsd(t *testing.T) {
 	setupTest(t)
-	defer teardownTest(t)
+	t.Cleanup(func() { teardownTest(t) })
 	pgDumpOut := `
 [
  { "pgid": "1.01", "up": [ 77, 1, 2 ], "acting": [ 77, 1, 2 ] },
@@ -123,4 +123,162 @@ func TestPgCountsByOsd(t *testing.T) {
 	require.Equal(t, 1, c[2])
 	require.Equal(t, 1, c[3])
 	require.Equal(t, 1, c[4])
+}
+
+func TestBackfillStatePrePopulatesAllKnownOSDs(t *testing.T) {
+	setupTest(t)
+	t.Cleanup(func() { teardownTest(t) })
+
+	pgDumpOut := `
+[
+ { "pgid": "1.01", "up": [ 1, 2, 3 ], "acting": [ 1, 2, 3 ] },
+ { "pgid": "1.02", "up": [ 4, 5, 6 ], "acting": [ 4, 5, 9 ] }
+]
+`
+	runOsdDump = func() (string, error) { return "{}", nil }
+	runPgDumpPgsBrief = func() (string, error) { return pgDumpOut, nil }
+
+	bs := mustGetCurrentBackfillState()
+
+	for _, osd := range []int{1, 2, 3, 4, 5, 6, 9} {
+		_, ok := bs.osds[osd]
+		require.True(t, ok, "osd %d should be pre-populated in bs.osds", osd)
+	}
+}
+
+func TestHasRoomForRemapDoesNotMutateState(t *testing.T) {
+	setupTest(t)
+	t.Cleanup(func() { teardownTest(t) })
+
+	pgDumpOut := `
+[
+ { "pgid": "1.01", "up": [ 77, 1, 2 ], "acting": [ 77, 1, 2 ] },
+ { "pgid": "1.02", "up": [ 77, 3, 4 ], "acting": [ 77, 3, 5 ] },
+ { "pgid": "1.03", "up": [ 77, 5, 6 ], "acting": [ 3, 5, 7 ] }
+]
+`
+	runOsdDump = func() (string, error) { return "{}", nil }
+	runPgDumpPgsBrief = func() (string, error) { return pgDumpOut, nil }
+
+	bs := mustGetCurrentBackfillState()
+
+	type osdCounters struct {
+		local, remote, from, max int
+	}
+	snapshotOSDs := func() map[int]osdCounters {
+		out := make(map[int]osdCounters, len(bs.osds))
+		for osd, s := range bs.osds {
+			out[osd] = osdCounters{
+				local:  s.localReservations,
+				remote: s.remoteReservations,
+				from:   s.backfillsFrom,
+				max:    s.maxBackfillReservations,
+			}
+		}
+		return out
+	}
+	snapshotUp := func() map[string][]int {
+		out := make(map[string][]int, len(bs.pgbs))
+		for id, pgb := range bs.pgbs {
+			dup := make([]int, len(pgb.Up))
+			copy(dup, pgb.Up)
+			out[id] = dup
+		}
+		return out
+	}
+
+	beforeOSDs := snapshotOSDs()
+	beforeUp := snapshotUp()
+
+	// Valid remap probe path; hasRoomForRemap applies and reverts internally.
+	_ = bs.hasRoomForRemap("1.02", 4, 5)
+
+	require.Equal(t, beforeOSDs, snapshotOSDs())
+	require.Equal(t, beforeUp, snapshotUp())
+}
+
+func TestHasRoomForRemapRespectsSourceAndTargetLimits(t *testing.T) {
+	setupTest(t)
+	t.Cleanup(func() { teardownTest(t) })
+
+	pgDumpOut := `
+[
+ { "pgid": "1.01", "up": [ 77, 1, 2 ], "acting": [ 77, 1, 2 ] },
+ { "pgid": "1.02", "up": [ 77, 3, 4 ], "acting": [ 77, 3, 5 ] },
+ { "pgid": "1.03", "up": [ 77, 5, 6 ], "acting": [ 3, 5, 7 ] }
+]
+`
+	runOsdDump = func() (string, error) { return "{}", nil }
+	runPgDumpPgsBrief = func() (string, error) { return pgDumpOut, nil }
+
+	t.Run("source backfill limit", func(t *testing.T) {
+		bs := mustGetCurrentBackfillState()
+		// from=4 currently has no source backfills; cap at 0 blocks it.
+		bs.maxBackfillsFrom = 0
+		require.False(t, bs.hasRoomForRemap("1.02", 4, 5))
+	})
+
+	t.Run("target reservation limit", func(t *testing.T) {
+		bs := mustGetCurrentBackfillState()
+		// Make source limit permissive so target-side check is exercised.
+		bs.maxBackfillsFrom = 1000
+
+		// 1.01 is currently clean. Remapping 1->6 introduces backfill with target=6.
+		// Cap target OSD 6 at zero reservations so this must be rejected.
+		bs.osd(6).maxBackfillReservations = 0
+		require.False(t, bs.hasRoomForRemap("1.01", 1, 6))
+	})
+}
+
+func TestComputeBackfillSrcsTgts(t *testing.T) {
+	t.Run("mismatches produce aligned src and tgt sets", func(t *testing.T) {
+		pgb := &pgBriefItem{
+			PgID:   "1.2",
+			Up:     []int{1, 2, 33, 4, 55, 6},
+			Acting: []int{1, 22, 3, 4, 5, 66},
+		}
+
+		var srcBuf [8]int
+		var tgtBuf [8]int
+		srcs, tgts := computeBackfillSrcsTgts(pgb, srcBuf[:0], tgtBuf[:0])
+
+		require.Equal(t, []int{22, 3, 5, 66}, srcs)
+		require.Equal(t, []int{2, 33, 55, 6}, tgts)
+	})
+
+	t.Run("no mismatches produce empty sets", func(t *testing.T) {
+		pgb := &pgBriefItem{
+			PgID:   "1.3",
+			Up:     []int{1, 2, 3},
+			Acting: []int{1, 2, 3},
+		}
+
+		var srcBuf [8]int
+		var tgtBuf [8]int
+		srcs, tgts := computeBackfillSrcsTgts(pgb, srcBuf[:0], tgtBuf[:0])
+
+		require.Empty(t, srcs)
+		require.Empty(t, tgts)
+	})
+
+	t.Run("supports entries larger than reusable buffer", func(t *testing.T) {
+		up := make([]int, 10)
+		acting := make([]int, 10)
+		expectSrc := make([]int, 10)
+		expectTgt := make([]int, 10)
+		for i := range 10 {
+			acting[i] = i
+			up[i] = 100 + i
+			expectSrc[i] = i
+			expectTgt[i] = 100 + i
+		}
+		pgb := &pgBriefItem{PgID: "1.4", Up: up, Acting: acting}
+
+		var srcBuf [8]int
+		var tgtBuf [8]int
+		srcs, tgts := computeBackfillSrcsTgts(pgb, srcBuf[:0], tgtBuf[:0])
+
+		require.Equal(t, expectSrc, srcs)
+		require.Equal(t, expectTgt, tgts)
+	})
 }

--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -1,0 +1,863 @@
+// Copyright 2021 DigitalOcean
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+)
+
+type benchmarkFixture struct {
+	pgDump  string
+	osdDump string
+	osdTree string
+	poolLs  string
+}
+
+func resetBenchmarkGlobals() {
+	savedOsdDumpOut = nil
+	savedOsdPoolsDetails = nil
+	savedParsedOsdTree = nil
+	savedPgDumpPgsBrief = nil
+	savedPgUpmapItemMap = nil
+	savedPgUpmapItemMapSource = nil
+
+	M = nil
+}
+
+func installFixture(f benchmarkFixture) {
+	runOsdDump = func() (string, error) { return f.osdDump, nil }
+	runPgDumpPgsBrief = func() (string, error) { return f.pgDump, nil }
+	runOsdTree = func() (string, error) { return f.osdTree, nil }
+	runOsdPoolLs = func() (string, error) { return f.poolLs, nil }
+	runCrushCmp = func(_ string) (string, error) {
+		panic("runCrushCmp should not be called in this benchmark")
+	}
+	runPgQuery = func(_ string) (string, error) {
+		panic("runPgQuery should not be called in benchmarks")
+	}
+}
+
+func makePoolJSON() string {
+	return `[
+ { "pool_id": 1, "pool_name": "replicated", "erasure_code_profile": "" }
+]`
+}
+
+func makeOsdDumpJSON(osdCount int) string {
+	var b strings.Builder
+	b.Grow(osdCount * 40)
+	b.WriteString("{\n  \"osds\": [\n")
+	for i := range osdCount {
+		if i > 0 {
+			b.WriteString(",\n")
+		}
+		fmt.Fprintf(&b, "    { \"osd\": %d, \"in\": 1, \"up\": 1 }", i)
+	}
+	b.WriteString("\n  ],\n  \"pg_upmap_items\": []\n}\n")
+	return b.String()
+}
+
+func makeOsdDumpJSONWithUpmaps(osdCount int, upmapCount int) string {
+	if upmapCount < 0 {
+		upmapCount = 0
+	}
+
+	var b strings.Builder
+	b.Grow(osdCount*40 + upmapCount*80)
+	b.WriteString("{\n  \"osds\": [\n")
+	for i := range osdCount {
+		if i > 0 {
+			b.WriteString(",\n")
+		}
+		fmt.Fprintf(&b, "    { \"osd\": %d, \"in\": 1, \"up\": 1 }", i)
+	}
+
+	b.WriteString("\n  ],\n  \"pg_upmap_items\": [\n")
+	for i := 0; i < upmapCount; i++ {
+		if i > 0 {
+			b.WriteString(",\n")
+		}
+		from := (i + 13) % osdCount
+		to := (from + 5) % osdCount
+		if to == from {
+			to = (to + 1) % osdCount
+		}
+		fmt.Fprintf(
+			&b,
+			"    { \"pgid\": \"1.%x\", \"mappings\": [ { \"from\": %d, \"to\": %d } ] }",
+			i,
+			from,
+			to,
+		)
+	}
+	b.WriteString("\n  ]\n}\n")
+	return b.String()
+}
+
+func makeOsdTreeJSON(osdCount int, osdsPerHost int) string {
+	if osdsPerHost <= 0 {
+		osdsPerHost = 8
+	}
+	hostCount := (osdCount + osdsPerHost - 1) / osdsPerHost
+
+	var b strings.Builder
+	b.Grow(osdCount * 50)
+	b.WriteString("{\n  \"nodes\": [\n")
+	b.WriteString("    { \"id\": -1, \"name\": \"default\", \"type\": \"root\", \"children\": [")
+	for h := range hostCount {
+		if h > 0 {
+			b.WriteString(",")
+		}
+		fmt.Fprintf(&b, "%d", -1000-h)
+	}
+	b.WriteString("] },\n")
+
+	for h := range hostCount {
+		if h > 0 {
+			b.WriteString(",\n")
+		}
+		start := h * osdsPerHost
+		end := min(start+osdsPerHost, osdCount)
+		fmt.Fprintf(&b, "    { \"id\": %d, \"name\": \"host%d\", \"type\": \"host\", \"children\": [", -1000-h, h)
+		for i := start; i < end; i++ {
+			if i > start {
+				b.WriteString(",")
+			}
+			fmt.Fprintf(&b, "%d", i)
+		}
+		b.WriteString("] }")
+	}
+
+	for i := range osdCount {
+		b.WriteString(",\n")
+		fmt.Fprintf(&b, "    { \"id\": %d, \"name\": \"osd.%d\", \"type\": \"osd\", \"reweight\": 1.0 }", i, i)
+	}
+	b.WriteString("\n  ]\n}\n")
+	return b.String()
+}
+
+func makeBenchmarkPgStats(pgCount int, osdCount int) []*pgBriefItem {
+	pgStats := make([]*pgBriefItem, 0, pgCount)
+	for i := range pgCount {
+		a0 := i % osdCount
+		a1 := (i + 7) % osdCount
+		a2 := (i + 13) % osdCount
+
+		u0 := a0
+		u1 := a1
+		u2 := a2
+		state := "active+clean"
+		if i%3 == 0 {
+			u2 = (a2 + 5) % osdCount
+			if u2 == a0 || u2 == a1 {
+				u2 = (u2 + 11) % osdCount
+			}
+			state = "active+remapped+backfill_wait"
+		}
+
+		pgStats = append(pgStats, &pgBriefItem{
+			PgID:   fmt.Sprintf("1.%x", i),
+			State:  state,
+			Up:     []int{u0, u1, u2},
+			Acting: []int{a0, a1, a2},
+		})
+	}
+
+	return pgStats
+}
+
+func makePgDumpJSON(pgCount int, osdCount int) string {
+	pgStats := makeBenchmarkPgStats(pgCount, osdCount)
+
+	out, err := json.Marshal(pgBriefNautilus{PgStats: pgStats})
+	if err != nil {
+		panic(err)
+	}
+	return string(out)
+}
+
+func makePgDumpJSONLegacy(pgCount int, osdCount int) string {
+	pgStats := makeBenchmarkPgStats(pgCount, osdCount)
+
+	out, err := json.Marshal(pgStats)
+	if err != nil {
+		panic(err)
+	}
+	return string(out)
+}
+
+func makeBenchmarkFixture(pgCount int, osdCount int) benchmarkFixture {
+	return benchmarkFixture{
+		pgDump:  makePgDumpJSON(pgCount, osdCount),
+		osdDump: makeOsdDumpJSON(osdCount),
+		osdTree: makeOsdTreeJSON(osdCount, 8),
+		poolLs:  makePoolJSON(),
+	}
+}
+
+func makeBenchmarkFixtureLegacy(pgCount int, osdCount int) benchmarkFixture {
+	f := makeBenchmarkFixture(pgCount, osdCount)
+	f.pgDump = makePgDumpJSONLegacy(pgCount, osdCount)
+	return f
+}
+
+func makeBenchmarkFixtureWithUpmaps(pgCount int, osdCount int, upmapCount int) benchmarkFixture {
+	if upmapCount > pgCount {
+		upmapCount = pgCount
+	}
+
+	return benchmarkFixture{
+		pgDump:  makePgDumpJSON(pgCount, osdCount),
+		osdDump: makeOsdDumpJSONWithUpmaps(osdCount, upmapCount),
+		osdTree: makeOsdTreeJSON(osdCount, 8),
+		poolLs:  makePoolJSON(),
+	}
+}
+
+func makeSyntheticImportMappings(count int, osdCount int) []pgMapping {
+	out := make([]pgMapping, count)
+	for i := range count {
+		from := (i + 13) % osdCount
+		to := (from + 17) % osdCount
+		if to == from {
+			to = (to + 1) % osdCount
+		}
+		out[i] = pgMapping{
+			PgID: fmt.Sprintf("1.%x", i),
+			Mapping: mapping{
+				From: from,
+				To:   to,
+			},
+		}
+	}
+	return out
+}
+
+func makeSyntheticCrushDiffOutput(pgCount int, osdCount int) string {
+	var b strings.Builder
+	b.Grow(pgCount * 60)
+	b.WriteString("# synthetic crushdiff output\n")
+	for i := range pgCount {
+		a0 := i % osdCount
+		a1 := (i + 7) % osdCount
+		a2 := (i + 13) % osdCount
+		n2 := (a2 + 5) % osdCount
+		if n2 == a0 || n2 == a1 {
+			n2 = (n2 + 11) % osdCount
+		}
+		fmt.Fprintf(&b, "1.%x\t[%d, %d, %d] -> [%d, %d, %d]\n", i, a0, a1, a2, a0, a1, n2)
+	}
+	return b.String()
+}
+
+func BenchmarkMustGetCurrentMappingState(b *testing.B) {
+	for _, tt := range []struct {
+		name     string
+		pgCount  int
+		osdCount int
+	}{
+		{name: "small", pgCount: 4096, osdCount: 128},
+		{name: "medium", pgCount: 16384, osdCount: 512},
+		{name: "large", pgCount: 65536, osdCount: 2048},
+	} {
+		fixture := makeBenchmarkFixture(tt.pgCount, tt.osdCount)
+
+		b.Run(tt.name, func(b *testing.B) {
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				resetBenchmarkGlobals()
+				installFixture(fixture)
+
+				_ = mustGetCurrentMappingState()
+			}
+		})
+	}
+}
+
+func BenchmarkMustGetCurrentMappingStateLegacyJSON(b *testing.B) {
+	for _, tt := range []struct {
+		name     string
+		pgCount  int
+		osdCount int
+	}{
+		{name: "small", pgCount: 4096, osdCount: 128},
+		{name: "medium", pgCount: 16384, osdCount: 512},
+		{name: "large", pgCount: 65536, osdCount: 2048},
+	} {
+		fixture := makeBenchmarkFixtureLegacy(tt.pgCount, tt.osdCount)
+
+		b.Run(tt.name, func(b *testing.B) {
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				resetBenchmarkGlobals()
+				installFixture(fixture)
+
+				_ = mustGetCurrentMappingState()
+			}
+		})
+	}
+}
+
+func BenchmarkCalcPgMappingsToUndoBackfill(b *testing.B) {
+	for _, tt := range []struct {
+		name     string
+		pgCount  int
+		osdCount int
+	}{
+		{name: "small", pgCount: 4096, osdCount: 128},
+		{name: "medium", pgCount: 16384, osdCount: 512},
+		{name: "large", pgCount: 65536, osdCount: 2048},
+	} {
+		fixture := makeBenchmarkFixture(tt.pgCount, tt.osdCount)
+
+		b.Run(tt.name, func(b *testing.B) {
+			b.ReportAllocs()
+
+			excludedOsds := map[int]struct{}{}
+			includedOsds := map[int]struct{}{}
+			excludedPools := map[int]struct{}{}
+			includedPools := map[int]struct{}{}
+			pgsIncludingOsds := map[int]struct{}{}
+
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				resetBenchmarkGlobals()
+				installFixture(fixture)
+				M = mustGetCurrentMappingState()
+
+				calcPgMappingsToUndoBackfill(
+					true,
+					false,
+					false,
+					excludedOsds,
+					includedOsds,
+					excludedPools,
+					includedPools,
+					pgsIncludingOsds,
+				)
+			}
+		})
+	}
+}
+
+func BenchmarkCalcPgMappingsToDrainOsd(b *testing.B) {
+	for _, tt := range []struct {
+		name     string
+		pgCount  int
+		osdCount int
+	}{
+		{name: "small", pgCount: 4096, osdCount: 128},
+		{name: "medium", pgCount: 16384, osdCount: 512},
+		{name: "large", pgCount: 65536, osdCount: 2048},
+	} {
+		fixture := makeBenchmarkFixture(tt.pgCount, tt.osdCount)
+
+		targets := make(map[int]struct{})
+		for i := 1; i < tt.osdCount && i < 64; i++ {
+			targets[i] = struct{}{}
+		}
+
+		b.Run(tt.name, func(b *testing.B) {
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				resetBenchmarkGlobals()
+				installFixture(fixture)
+				M = mustGetCurrentMappingState()
+				M.bs.maxBackfillsFrom = 4096
+
+				calcPgMappingsToDrainOsd("", []int{0}, targets)
+			}
+		})
+	}
+}
+
+func BenchmarkCalcPgMappingsToUndoUpmaps(b *testing.B) {
+	for _, tt := range []struct {
+		name       string
+		pgCount    int
+		osdCount   int
+		upmapCount int
+	}{
+		{name: "small", pgCount: 4096, osdCount: 128, upmapCount: 300},
+		{name: "medium", pgCount: 16384, osdCount: 512, upmapCount: 1200},
+		{name: "large", pgCount: 65536, osdCount: 2048, upmapCount: 4800},
+	} {
+		fixture := makeBenchmarkFixtureWithUpmaps(tt.pgCount, tt.osdCount, tt.upmapCount)
+
+		osds := make([]int, 0, 16)
+		for i := 0; i < 16 && i < tt.osdCount; i++ {
+			osds = append(osds, i)
+		}
+
+		b.Run(tt.name, func(b *testing.B) {
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				resetBenchmarkGlobals()
+				installFixture(fixture)
+				M = mustGetCurrentMappingState()
+				M.bs.maxBackfillsFrom = 4096
+
+				calcPgMappingsToUndoUpmaps(osds, false)
+			}
+		})
+	}
+}
+
+func BenchmarkCalcPgMappingsToBalanceOsds(b *testing.B) {
+	for _, tt := range []struct {
+		name     string
+		pgCount  int
+		osdCount int
+	}{
+		{name: "small", pgCount: 4096, osdCount: 128},
+		{name: "medium", pgCount: 16384, osdCount: 512},
+		{name: "large", pgCount: 65536, osdCount: 2048},
+	} {
+		fixture := makeBenchmarkFixture(tt.pgCount, tt.osdCount)
+
+		osds := make([]int, 0, 32)
+		for i := 0; i < 32 && i < tt.osdCount; i++ {
+			osds = append(osds, i)
+		}
+
+		b.Run(tt.name, func(b *testing.B) {
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				resetBenchmarkGlobals()
+				installFixture(fixture)
+				M = mustGetCurrentMappingState()
+
+				calcPgMappingsToBalanceOsds(osds, 64, 1)
+			}
+		})
+	}
+}
+
+func BenchmarkImportMappingsLoop(b *testing.B) {
+	for _, tt := range []struct {
+		name       string
+		pgCount    int
+		osdCount   int
+		upmapCount int
+	}{
+		{name: "small", pgCount: 4096, osdCount: 128, upmapCount: 300},
+		{name: "medium", pgCount: 16384, osdCount: 512, upmapCount: 1200},
+		{name: "large", pgCount: 65536, osdCount: 2048, upmapCount: 4800},
+	} {
+		fixture := makeBenchmarkFixtureWithUpmaps(tt.pgCount, tt.osdCount, tt.upmapCount)
+		imports := makeSyntheticImportMappings(tt.upmapCount, tt.osdCount)
+
+		b.Run(tt.name, func(b *testing.B) {
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				resetBenchmarkGlobals()
+				installFixture(fixture)
+				M = mustGetCurrentMappingState()
+
+				for _, m := range imports {
+					pui := M.findOrMakeUpmapItem(m.PgID)
+					found := false
+					for _, puiM := range pui.Mappings {
+						if puiM.From == m.Mapping.From {
+							M.mustRemap(m.PgID, puiM.To, m.Mapping.To)
+							found = true
+							break
+						}
+					}
+					if !found {
+						M.mustRemap(m.PgID, m.Mapping.From, m.Mapping.To)
+					}
+				}
+			}
+		})
+	}
+}
+
+func BenchmarkExportMappings(b *testing.B) {
+	for _, tt := range []struct {
+		name       string
+		pgCount    int
+		osdCount   int
+		upmapCount int
+	}{
+		{name: "small", pgCount: 4096, osdCount: 128, upmapCount: 300},
+		{name: "medium", pgCount: 16384, osdCount: 512, upmapCount: 1200},
+		{name: "large", pgCount: 65536, osdCount: 2048, upmapCount: 4800},
+	} {
+		fixture := makeBenchmarkFixtureWithUpmaps(tt.pgCount, tt.osdCount, tt.upmapCount)
+
+		b.Run(tt.name, func(b *testing.B) {
+			b.ReportAllocs()
+
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				resetBenchmarkGlobals()
+				installFixture(fixture)
+				M = mustGetCurrentMappingState()
+
+				filters := make([]mappingFilter, 0, 16)
+				for osd := 0; osd < 8 && osd < tt.osdCount; osd++ {
+					filters = append(filters, withFrom(osd), withTo(osd))
+				}
+
+				mappings := M.getMappings(mfOr(filters...))
+
+				wholePgFilters := make([]mappingFilter, 0, len(mappings))
+				for _, mp := range mappings {
+					wholePgFilters = append(wholePgFilters, withPgid(mp.PgID))
+				}
+				_ = M.getMappings(mfOr(wholePgFilters...))
+			}
+		})
+	}
+}
+
+func BenchmarkRemapSingle(b *testing.B) {
+	for _, tt := range []struct {
+		name     string
+		pgCount  int
+		osdCount int
+	}{
+		{name: "small", pgCount: 4096, osdCount: 128},
+		{name: "medium", pgCount: 16384, osdCount: 512},
+		{name: "large", pgCount: 65536, osdCount: 2048},
+	} {
+		fixture := makeBenchmarkFixture(tt.pgCount, tt.osdCount)
+
+		b.Run(tt.name, func(b *testing.B) {
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				resetBenchmarkGlobals()
+				installFixture(fixture)
+				M = mustGetCurrentMappingState()
+
+				pgb, ok := M.bs.pgbs["1.0"]
+				if !ok || len(pgb.Up) == 0 {
+					b.Fatalf("missing benchmark PG 1.0 or empty up set")
+				}
+
+				from := pgb.Up[i%len(pgb.Up)]
+				to := (from + 17) % tt.osdCount
+				for _, upOsd := range pgb.Up {
+					if to == upOsd {
+						to = (to + 1) % tt.osdCount
+					}
+				}
+				if to == from {
+					to = (to + 1) % tt.osdCount
+				}
+
+				M.mustRemap("1.0", from, to)
+			}
+		})
+	}
+}
+
+func BenchmarkGenerateCrushChangeMappings(b *testing.B) {
+	for _, tt := range []struct {
+		name     string
+		pgCount  int
+		osdCount int
+	}{
+		{name: "small", pgCount: 4096, osdCount: 128},
+		{name: "medium", pgCount: 16384, osdCount: 512},
+		{name: "large", pgCount: 65536, osdCount: 2048},
+	} {
+		out := makeSyntheticCrushDiffOutput(tt.pgCount, tt.osdCount)
+
+		b.Run(tt.name, func(b *testing.B) {
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				resetBenchmarkGlobals()
+				runCrushCmp = func(_ string) (string, error) { return out, nil }
+
+				_, _ = crushCmp("synthetic")
+			}
+		})
+	}
+}
+
+func BenchmarkAccountForRemap(b *testing.B) {
+	for _, tt := range []struct {
+		name     string
+		pgCount  int
+		osdCount int
+	}{
+		{name: "small", pgCount: 4096, osdCount: 128},
+		{name: "medium", pgCount: 16384, osdCount: 512},
+		{name: "large", pgCount: 65536, osdCount: 2048},
+	} {
+		fixture := makeBenchmarkFixture(tt.pgCount, tt.osdCount)
+
+		resetBenchmarkGlobals()
+		installFixture(fixture)
+		bs := mustGetCurrentBackfillState()
+		pgb := bs.pgbs["1.1"]
+		if pgb == nil || len(pgb.Up) == 0 {
+			b.Fatalf("missing benchmark PG 1.1 or empty up set")
+		}
+
+		from := pgb.Up[0]
+		to := (from + 17) % tt.osdCount
+		for _, osd := range pgb.Up {
+			if to == osd {
+				to = (to + 1) % tt.osdCount
+			}
+		}
+
+		b.Run(tt.name, func(b *testing.B) {
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				bs.accountForRemap("1.1", from, to)
+				bs.accountForRemap("1.1", to, from)
+			}
+		})
+	}
+}
+
+func BenchmarkHasRoomForRemap(b *testing.B) {
+	for _, tt := range []struct {
+		name     string
+		pgCount  int
+		osdCount int
+	}{
+		{name: "small", pgCount: 4096, osdCount: 128},
+		{name: "medium", pgCount: 16384, osdCount: 512},
+		{name: "large", pgCount: 65536, osdCount: 2048},
+	} {
+		fixture := makeBenchmarkFixture(tt.pgCount, tt.osdCount)
+
+		resetBenchmarkGlobals()
+		installFixture(fixture)
+		bs := mustGetCurrentBackfillState()
+		pgb := bs.pgbs["1.2"]
+		if pgb == nil || len(pgb.Up) == 0 {
+			b.Fatalf("missing benchmark PG 1.2 or empty up set")
+		}
+
+		from := pgb.Up[0]
+		to := (from + 19) % tt.osdCount
+		for _, osd := range pgb.Up {
+			if to == osd {
+				to = (to + 1) % tt.osdCount
+			}
+		}
+		bs.maxBackfillsFrom = 1 << 30
+
+		b.Run(tt.name, func(b *testing.B) {
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				_ = bs.hasRoomForRemap("1.2", from, to)
+			}
+		})
+	}
+}
+
+func BenchmarkComputeBackfillSrcsTgts(b *testing.B) {
+	pgb := &pgBriefItem{
+		PgID:   "1.bench",
+		State:  "active+remapped+backfill_wait",
+		Up:     []int{1, 2, 33, 4, 55, 6},
+		Acting: []int{1, 22, 3, 4, 5, 66},
+	}
+	var srcBuf [8]int
+	var tgtBuf [8]int
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, _ = computeBackfillSrcsTgts(pgb, srcBuf[:0], tgtBuf[:0])
+	}
+}
+
+func BenchmarkSanitizeStaleUpmaps(b *testing.B) {
+	for _, tt := range []struct {
+		name     string
+		pgCount  int
+		osdCount int
+	}{
+		{name: "small", pgCount: 4096, osdCount: 128},
+		{name: "medium", pgCount: 16384, osdCount: 512},
+		{name: "large", pgCount: 65536, osdCount: 2048},
+	} {
+		fixture := makeBenchmarkFixture(tt.pgCount, tt.osdCount)
+
+		b.Run(tt.name, func(b *testing.B) {
+			b.ReportAllocs()
+			b.ResetTimer()
+
+			for i := 0; i < b.N; i++ {
+				resetBenchmarkGlobals()
+				installFixture(fixture)
+
+				puis := make([]*pgUpmapItem, 0, tt.pgCount)
+				for p := range tt.pgCount {
+					pgid := fmt.Sprintf("1.%x", p)
+					puis = append(puis, &pgUpmapItem{
+						PgID: pgid,
+						Mappings: []mapping{
+							{From: p % tt.osdCount, To: (p + 17) % tt.osdCount},
+							{From: (p + 23) % tt.osdCount, To: (p + 31) % tt.osdCount},
+							{From: (p + 29) % tt.osdCount, To: (p + 37) % tt.osdCount},
+						},
+					})
+				}
+
+				sanitizeStaleUpmaps(puis)
+			}
+		})
+	}
+}
+
+func BenchmarkGetMappingsFilterCompositions(b *testing.B) {
+	for _, tt := range []struct {
+		name       string
+		pgCount    int
+		osdCount   int
+		upmapCount int
+	}{
+		{name: "small", pgCount: 4096, osdCount: 128, upmapCount: 300},
+		{name: "medium", pgCount: 16384, osdCount: 512, upmapCount: 1200},
+		{name: "large", pgCount: 65536, osdCount: 2048, upmapCount: 4800},
+	} {
+		fixture := makeBenchmarkFixtureWithUpmaps(tt.pgCount, tt.osdCount, tt.upmapCount)
+
+		b.Run(tt.name, func(b *testing.B) {
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				resetBenchmarkGlobals()
+				installFixture(fixture)
+				M = mustGetCurrentMappingState()
+
+				filters := make([]mappingFilter, 0, 16)
+				for osd := range 8 {
+					filters = append(filters, withFrom(osd), withTo(osd))
+				}
+
+				_ = M.getMappings(mfOr(filters...))
+			}
+		})
+	}
+}
+
+func BenchmarkTryRemapConflictAndUpdatePaths(b *testing.B) {
+	for _, tt := range []struct {
+		name       string
+		pgCount    int
+		osdCount   int
+		upmapCount int
+	}{
+		{name: "small", pgCount: 4096, osdCount: 128, upmapCount: 300},
+		{name: "medium", pgCount: 16384, osdCount: 512, upmapCount: 1200},
+		{name: "large", pgCount: 65536, osdCount: 2048, upmapCount: 4800},
+	} {
+		fixture := makeBenchmarkFixtureWithUpmaps(tt.pgCount, tt.osdCount, tt.upmapCount)
+
+		b.Run("update-existing/"+tt.name, func(b *testing.B) {
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				resetBenchmarkGlobals()
+				installFixture(fixture)
+				M = mustGetCurrentMappingState()
+
+				_ = M.tryRemap("1.0", 18, 25)
+			}
+		})
+	}
+
+	b.Run("conflict", func(b *testing.B) {
+		runOsdPoolLs = func() (string, error) {
+			return `[{"pool_id":1,"pool_name":"replicated","erasure_code_profile":""}]`, nil
+		}
+
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			resetBenchmarkGlobals()
+			runOsdDump = func() (string, error) {
+				return `{
+					"pg_upmap_items": [
+						{"pgid":"1.1","mappings":[{"from":3,"to":4},{"from":5,"to":6}]}
+					]
+				}`, nil
+			}
+			runPgDumpPgsBrief = func() (string, error) {
+				return `[
+					{"pgid":"1.1","state":"active+remapped","up":[4,6],"acting":[3,5]}
+				]`, nil
+			}
+
+			M = mustGetCurrentMappingState()
+			_ = M.tryRemap("1.1", 7, 4)
+		}
+	})
+}
+
+func BenchmarkParseCrushDiff(b *testing.B) {
+	for _, tt := range []struct {
+		name     string
+		pgCount  int
+		osdCount int
+	}{
+		{name: "small", pgCount: 4096, osdCount: 128},
+		{name: "medium", pgCount: 16384, osdCount: 512},
+		{name: "large", pgCount: 65536, osdCount: 2048},
+	} {
+		out := makeSyntheticCrushDiffOutput(tt.pgCount, tt.osdCount)
+
+		b.Run(tt.name, func(b *testing.B) {
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				_, _ = parseCrushDiff(out)
+			}
+		})
+	}
+}
+
+func BenchmarkParsePGRemapEntry(b *testing.B) {
+	line := "1.abc\t[1, 22, 333] -> [1, 44, 333]"
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, _ = parsePGRemapEntry(line)
+	}
+}
+
+func BenchmarkHandleCephInf(b *testing.B) {
+	buf := []byte(`{"a": inf, "b":inf, "nested":{"x":1}, "arr":[1,2,3]}`)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = handleCephInf(buf)
+	}
+}

--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021 DigitalOcean
+// Copyright 2026 DigitalOcean
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -678,6 +678,62 @@ func BenchmarkHasRoomForRemap(b *testing.B) {
 	}
 }
 
+func BenchmarkAddReservations(b *testing.B) {
+	for _, tt := range []struct {
+		name     string
+		pgCount  int
+		osdCount int
+	}{
+		{name: "small", pgCount: 4096, osdCount: 128},
+		{name: "medium", pgCount: 16384, osdCount: 512},
+		{name: "large", pgCount: 65536, osdCount: 2048},
+	} {
+		pgStats := makeBenchmarkPgStats(tt.pgCount, tt.osdCount)
+
+		b.Run(tt.name, func(b *testing.B) {
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				bs := makeBackfillState()
+				for _, pgb := range pgStats {
+					bs.addReservations(pgb)
+				}
+			}
+		})
+	}
+}
+
+func BenchmarkRemoveReservations(b *testing.B) {
+	for _, tt := range []struct {
+		name     string
+		pgCount  int
+		osdCount int
+	}{
+		{name: "small", pgCount: 4096, osdCount: 128},
+		{name: "medium", pgCount: 16384, osdCount: 512},
+		{name: "large", pgCount: 65536, osdCount: 2048},
+	} {
+		pgStats := makeBenchmarkPgStats(tt.pgCount, tt.osdCount)
+
+		b.Run(tt.name, func(b *testing.B) {
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				b.StopTimer()
+				bs := makeBackfillState()
+				for _, pgb := range pgStats {
+					bs.addReservations(pgb)
+				}
+				b.StartTimer()
+
+				for _, pgb := range pgStats {
+					bs.removeReservations(pgb)
+				}
+			}
+		})
+	}
+}
+
 func BenchmarkComputeBackfillSrcsTgts(b *testing.B) {
 	pgb := &pgBriefItem{
 		PgID:   "1.bench",
@@ -685,8 +741,8 @@ func BenchmarkComputeBackfillSrcsTgts(b *testing.B) {
 		Up:     []int{1, 2, 33, 4, 55, 6},
 		Acting: []int{1, 22, 3, 4, 5, 66},
 	}
-	var srcBuf [8]int
-	var tgtBuf [8]int
+	srcBuf := make([]int, 0, len(pgb.Acting))
+	tgtBuf := make([]int, 0, len(pgb.Acting))
 
 	b.ReportAllocs()
 	b.ResetTimer()

--- a/ceph.go
+++ b/ceph.go
@@ -21,7 +21,7 @@ import (
 	"fmt"
 	"math"
 	"regexp"
-	"sort"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -42,7 +42,6 @@ var (
 	runCrushCmp       = func(path string) (string, error) { return runCombined("crushdiff", "compare", path, "--verbose") }
 
 	pgQueryPeerRegexp = regexp.MustCompile(`(?P<osd>[0-9]+)(?:\((?P<index>[0-9]+)\))?`)
-	pgIdRegexp        = regexp.MustCompile(`(?P<pool>[0-9]+)\.(?P<id>[0-9a-f]+)`)
 )
 
 type pgUpmapItem struct {
@@ -95,6 +94,9 @@ type osdPoolDetail struct {
 
 type poolsDetails struct {
 	Pools map[int]*osdPoolDetail
+	// UsesEC caches whether each pool ID is erasure-coded, computed once at
+	// build time so PgUsesEC doesn't need to re-evaluate ECProfile on every call.
+	UsesEC map[int]bool
 }
 
 type parsedOsdTree struct {
@@ -289,23 +291,26 @@ func (pui *pgUpmapItem) do() {
 
 	cmd := []string{"ceph", "osd", "pg-upmap-items", pui.PgID}
 	for _, m := range pui.Mappings {
-		cmd = append(cmd, fmt.Sprintf("%d", m.From), fmt.Sprintf("%d", m.To))
+		cmd = append(cmd, strconv.Itoa(m.From), strconv.Itoa(m.To))
 	}
 	_ = runOrDie(cmd...)
 }
 
 // Detect whether a given PG belongs to an erasure-coded pool
 func (pd *poolsDetails) PgUsesEC(pgid string) bool {
-	m := pgIdRegexp.FindStringSubmatch(pgid)
-	if len(m) != 3 {
+	// PGID format is always "<poolid>.<hex>" — extract the pool ID with a
+	// simple byte scan rather than a regex to avoid per-call allocations.
+	m := strings.IndexByte(pgid, '.')
+	if m <= 0 {
 		panic(fmt.Sprintf("can't parse PGID %s", pgid))
 	}
-	poolId, err := strconv.Atoi(m[1])
+	poolId, err := strconv.Atoi(pgid[:m])
 	if err != nil {
 		panic(fmt.Sprintf("can't parse pool in PGID %s", pgid))
 	}
-	if pool, ok := pd.Pools[poolId]; ok {
-		return pool.ECProfile != ""
+	// UsesEC was precomputed when poolsDetails was built; no string comparison needed here.
+	if usesEC, ok := pd.UsesEC[poolId]; ok {
+		return usesEC
 	}
 	panic(fmt.Sprintf("could not find pool data for PG %s", pgid))
 }
@@ -373,6 +378,8 @@ func countCurrentBackfills() (map[int]int, map[int]int) {
 }
 
 var savedPgDumpPgsBrief []*pgBriefItem
+var savedPgUpmapItemMap map[string]*pgUpmapItem
+var savedPgUpmapItemMapSource *osdDumpOut
 
 func pgDumpPgsBrief() []*pgBriefItem {
 	if len(savedPgDumpPgsBrief) > 0 {
@@ -386,18 +393,29 @@ func pgDumpPgsBrief() []*pgBriefItem {
 
 	var pgBriefs []*pgBriefItem
 
-	if err := json.Unmarshal([]byte(out), &pgBriefs); err != nil {
-		// Newer versions of Ceph have a slightly different structure.
-		var pgBriefNautilusOut pgBriefNautilus
-		if err := json.Unmarshal([]byte(out), &pgBriefNautilusOut); err != nil {
+	// Try Nautilus+ style wrapper first, then fall back to direct array format.
+	var pgBriefNautilusOut pgBriefNautilus
+	if err := json.Unmarshal([]byte(out), &pgBriefNautilusOut); err == nil {
+		pgBriefs = pgBriefNautilusOut.PgStats
+	} else {
+		if err := json.Unmarshal([]byte(out), &pgBriefs); err != nil {
 			panic(errors.WithStack(err))
 		}
-		pgBriefs = pgBriefNautilusOut.PgStats
 	}
 	pgBriefs = sanitizePgBriefs(pgBriefs)
+	pools := osdPoolDetails()
+	upmapItemsByPg := pgUpmapItemMap()
 
 	for _, pgb := range pgBriefs {
-		reorderUpToMatchActing(pgb.PgID, pgb.Up, pgb.Acting, true)
+		// Fast path: if up already matches acting and no upmap item exists
+		// for this PG, reordering cannot change anything.
+		if slices.Equal(pgb.Up, pgb.Acting) {
+			if _, ok := upmapItemsByPg[pgb.PgID]; !ok {
+				continue
+			}
+		}
+
+		reorderUpToMatchActingWithContext(pgb.PgID, pgb.Up, pgb.Acting, true, pools, upmapItemsByPg)
 	}
 
 	savedPgDumpPgsBrief = pgBriefs
@@ -406,7 +424,8 @@ func pgDumpPgsBrief() []*pgBriefItem {
 
 func sanitizePgBriefs(pgBriefs []*pgBriefItem) []*pgBriefItem {
 	duplicateMessage := "WARNING: PG %s's %s set has one or more duplicated OSD IDs; this PG will be excluded from operations and reservation calculations. Please check your CRUSH rules and map.\n"
-	sanitized := make([]*pgBriefItem, 0, len(pgBriefs))
+	sanitized := pgBriefs
+	i := 0
 
 	for _, pgBrief := range pgBriefs {
 		if len(pgBrief.Up) != len(pgBrief.Acting) {
@@ -424,38 +443,25 @@ func sanitizePgBriefs(pgBriefs []*pgBriefItem) []*pgBriefItem {
 			continue
 		}
 
-		sanitized = append(sanitized, pgBrief)
+		sanitized[i] = pgBrief
+		i++
 	}
 
-	return sanitized
+	return sanitized[:i]
 }
 
 func hasDuplicateOSDID(osdids []int) bool {
-	for i, osdid := range osdids {
+	seen := make(map[int]struct{}, len(osdids))
+	for _, osdid := range osdids {
 		if osdid == invalidOSD {
 			continue
 		}
-		for j, otherOSDID := range osdids {
-			if i == j {
-				continue
-			}
-			if osdid == otherOSDID {
-				return true
-			}
+		if _, ok := seen[osdid]; ok {
+			return true
 		}
+		seen[osdid] = struct{}{}
 	}
 	return false
-}
-
-func pgBriefMap() map[string]*pgBriefItem {
-	pgBriefs := pgDumpPgsBrief()
-
-	pgBriefMap := make(map[string]*pgBriefItem)
-	for _, pgb := range pgBriefs {
-		pgBriefMap[pgb.PgID] = pgb
-	}
-
-	return pgBriefMap
 }
 
 // Re-order the up list so that any OSDs in it that are also in the
@@ -465,16 +471,27 @@ func pgBriefMap() map[string]*pgBriefItem {
 // matters and won't change, but for replicated pools the order can
 // change and this doesn't imply data movement.
 func reorderUpToMatchActing(pgid string, up, acting []int, useUpmap bool) {
+	reorderUpToMatchActingWithContext(pgid, up, acting, useUpmap, nil, nil)
+}
+
+func reorderUpToMatchActingWithContext(pgid string, up, acting []int, useUpmap bool, pools *poolsDetails, upmapItemsByPg map[string]*pgUpmapItem) {
 	// Do not reorder if the PG belongs to an Erasure-Coded pool,
 	// since order DOES matter and will trigger backfills.
-	pools := osdPoolDetails()
+	if pools == nil {
+		pools = osdPoolDetails()
+	}
 	if pools.PgUsesEC(pgid) {
 		return
 	}
 
-	mappings := make(map[int]int)
+	// Keep nil unless we actually have upmap entries for this PG.
+	// Lookups on a nil map are safe and return (zero, false).
+	var mappings map[int]int
 	if useUpmap {
-		if pui, ok := pgUpmapItemMap()[pgid]; ok {
+		if upmapItemsByPg == nil {
+			upmapItemsByPg = pgUpmapItemMap()
+		}
+		if pui, ok := upmapItemsByPg[pgid]; ok {
 			mappings = pui.mappingsAsToFromMap()
 		}
 	}
@@ -523,13 +540,19 @@ func osdDump() *osdDumpOut {
 
 func pgUpmapItemMap() map[string]*pgUpmapItem {
 	osdDumpOut := osdDump()
+	if savedPgUpmapItemMap != nil && savedPgUpmapItemMapSource == osdDumpOut {
+		return savedPgUpmapItemMap
+	}
 
-	puis := make(map[string]*pgUpmapItem)
+	puis := make(map[string]*pgUpmapItem, len(osdDumpOut.PgUpmapItems))
 	for _, pui := range osdDumpOut.PgUpmapItems {
 		puis[pui.PgID] = pui
 	}
 
-	return puis
+	savedPgUpmapItemMap = puis
+	savedPgUpmapItemMapSource = osdDumpOut
+
+	return savedPgUpmapItemMap
 }
 
 var savedParsedOsdTree *parsedOsdTree
@@ -592,11 +615,13 @@ func osdPoolDetails() *poolsDetails {
 	mustParseCephCommand(jsonOut, err, &pools)
 
 	poolsMap = make(map[int]*osdPoolDetail)
+	usesEC := make(map[int]bool, len(pools))
 	for _, pool := range pools {
 		poolsMap[pool.ID] = pool
+		usesEC[pool.ID] = pool.ECProfile != ""
 	}
 
-	savedOsdPoolsDetails = &poolsDetails{Pools: poolsMap}
+	savedOsdPoolsDetails = &poolsDetails{Pools: poolsMap, UsesEC: usesEC}
 	return savedOsdPoolsDetails
 }
 
@@ -620,7 +645,16 @@ func crushCmp(fp string) ([]pgMapping, error) {
 		panic(err)
 	}
 
-	mappings := make([]pgMapping, 0, len(puis))
+	mappingCount := 0
+	for _, pui := range puis {
+		for _, m := range pui.Mappings {
+			if m.From != m.To {
+				mappingCount++
+			}
+		}
+	}
+
+	mappings := make([]pgMapping, 0, mappingCount)
 	for _, pui := range puis {
 		for _, m := range pui.Mappings {
 			if m.From == m.To {
@@ -642,9 +676,19 @@ func crushCmp(fp string) ([]pgMapping, error) {
 
 func parseCrushDiff(in string) ([]*pgUpmapItem, error) {
 	var (
-		sc     = bufio.NewScanner(strings.NewReader(in))
-		puiMap = make(map[string]*pgUpmapItem)
+		sc = bufio.NewScanner(strings.NewReader(in))
 	)
+	// Most mapping lines are one-per-line in crushdiff output. Pre-sizing to
+	// newline count keeps this slice in a mostly single allocation.
+	estimate := max(strings.Count(in, "\n"), 1)
+	type parsedPGRemap struct {
+		seq int
+		pui *pgUpmapItem
+	}
+	parsed := make([]parsedPGRemap, 0, estimate)
+	seq := 0
+	monotonicByPGID := true
+	lastPGID := ""
 
 	for sc.Scan() {
 		line := strings.TrimSpace(sc.Text())
@@ -662,80 +706,119 @@ func parseCrushDiff(in string) ([]*pgUpmapItem, error) {
 			return nil, errors.Wrap(err, "could not parse PG mapping entry")
 		}
 
-		puiMap[pui.PgID] = pui
+		parsed = append(parsed, parsedPGRemap{seq: seq, pui: pui})
+		if lastPGID != "" && strings.Compare(lastPGID, pui.PgID) > 0 {
+			monotonicByPGID = false
+		}
+		lastPGID = pui.PgID
+		seq++
 	}
 
 	if err := sc.Err(); err != nil {
 		return nil, errors.Wrap(err, "failed scanning crushmap")
 	}
 
-	puis := make([]*pgUpmapItem, 0, len(puiMap))
-	for _, pui := range puiMap {
-		puis = append(puis, pui)
+	// Sort first by PG ID, then by input sequence so duplicate PG IDs keep
+	// deterministic order and can be deduplicated with "last one wins".
+	if !monotonicByPGID {
+		slices.SortFunc(parsed, func(a, b parsedPGRemap) int {
+			if c := strings.Compare(a.pui.PgID, b.pui.PgID); c != 0 {
+				return c
+			}
+			return a.seq - b.seq
+		})
 	}
 
-	sort.Slice(puis, func(i, j int) bool { return puis[i].PgID < puis[j].PgID })
+	puis := make([]*pgUpmapItem, 0, len(parsed))
+	for i := 0; i < len(parsed); {
+		j := i + 1
+		for j < len(parsed) && parsed[j].pui.PgID == parsed[i].pui.PgID {
+			j++
+		}
+		// Preserve existing semantics: when duplicate PG IDs appear, keep
+		// the last parsed entry.
+		puis = append(puis, parsed[j-1].pui)
+		i = j
+	}
+
 	return puis, nil
 }
 
 func parsePGRemapEntry(entry string) (*pgUpmapItem, error) {
-	parts := strings.Fields(entry)
-
-	// We expect at minimum the PG mapping entry should contain 4
-	// separate sections. For e.g.:
-	//
-	// 1.0 [3] -> [3]
-	if len(parts) < 4 {
+	// Extract PGID: everything before the first whitespace character.
+	sep := strings.IndexAny(entry, " \t")
+	if sep <= 0 {
 		return nil, fmt.Errorf("incomplete PG mapping entry: %q", entry)
 	}
+	pgID := entry[:sep]
+	rest := entry[sep+1:]
 
-	// There should also be even number of elements in the remapping entry.
-	if len(parts)%2 != 0 {
-		return nil, fmt.Errorf("invalid PG mapping entry: %q", entry)
+	// Split on "->": left-hand side is the existing OSD set, right-hand side is the new one.
+	before, after, ok := strings.Cut(rest, "->")
+	if !ok {
+		return nil, fmt.Errorf("incomplete PG mapping entry: %q", entry)
 	}
+	lhs := before
+	rhs := after
 
-	var (
-		pgID   = parts[0]
-		eM, nM = make([]int, 0, len(parts)/2), make([]int, 0, len(parts)/2)
-		nMM    bool
-	)
-	for _, part := range parts[1:] {
-		if part == "->" {
-			nMM = true
-			continue
+	// Scan lhs and rhs inline: skip non-digit characters and consume digit runs.
+	// This avoids the string splitting and trimming allocations of strings.Fields
+	// and strings.Trim.
+	mappings := make([]mapping, 0, 4)
+	for s := lhs; len(s) > 0; {
+		for len(s) > 0 && (s[0] < '0' || s[0] > '9') {
+			s = s[1:]
 		}
-
-		part = strings.Trim(part, "[],")
-
-		id, err := strconv.Atoi(part)
+		if len(s) == 0 {
+			break
+		}
+		end := 0
+		for end < len(s) && s[end] >= '0' && s[end] <= '9' {
+			end++
+		}
+		id, err := strconv.Atoi(s[:end])
 		if err != nil {
 			return nil, errors.Wrapf(err, "could not parse pg mapping entry for %q", entry)
 		}
-
-		if nMM {
-			nM = append(nM, id)
-			continue
-		}
-
-		eM = append(eM, id)
+		mappings = append(mappings, mapping{From: id})
+		s = s[end:]
 	}
 
-	// OSD sets should have the same length for both existing and new ones.
-	if len(eM) != len(nM) {
+	if len(mappings) == 0 {
 		return nil, fmt.Errorf("unequal count between existing and new OSD sets within mapping: %q", entry)
 	}
 
-	enM := make([]mapping, 0, len(nM))
-	for i := range nM {
-		enM = append(enM, mapping{
-			From: eM[i],
-			To:   nM[i],
-		})
+	toIdx := 0
+	for s := rhs; len(s) > 0; {
+		for len(s) > 0 && (s[0] < '0' || s[0] > '9') {
+			s = s[1:]
+		}
+		if len(s) == 0 {
+			break
+		}
+		end := 0
+		for end < len(s) && s[end] >= '0' && s[end] <= '9' {
+			end++
+		}
+		id, err := strconv.Atoi(s[:end])
+		if err != nil {
+			return nil, errors.Wrapf(err, "could not parse pg mapping entry for %q", entry)
+		}
+		if toIdx >= len(mappings) {
+			return nil, fmt.Errorf("unequal count between existing and new OSD sets within mapping: %q", entry)
+		}
+		mappings[toIdx].To = id
+		toIdx++
+		s = s[end:]
+	}
+
+	if toIdx != len(mappings) {
+		return nil, fmt.Errorf("unequal count between existing and new OSD sets within mapping: %q", entry)
 	}
 
 	return &pgUpmapItem{
 		PgID:     pgID,
-		Mappings: enM,
+		Mappings: mappings,
 	}, nil
 }
 
@@ -762,8 +845,16 @@ func parseCephCommand(out string, err error, v any) error {
 // the json spec or the golang parser (though it is apparently allowed by the
 // Python parser), so we convert such cases to "null".
 func handleCephInf(buf []byte) []byte {
-	buf = bytes.ReplaceAll(buf, []byte("\": inf"), []byte("\": null"))
-	buf = bytes.ReplaceAll(buf, []byte("\":inf"), []byte("\":null"))
-
+	// bytes.ReplaceAll always allocates a new buffer, even when the search
+	// pattern is not present. Guard each replacement with a Contains check
+	// so that the common case (no "inf" values) avoids the allocation entirely.
+	for _, pair := range [][2][]byte{
+		{[]byte("\": inf"), []byte("\": null")},
+		{[]byte("\":inf"), []byte("\":null")},
+	} {
+		if bytes.Contains(buf, pair[0]) {
+			buf = bytes.ReplaceAll(buf, pair[0], pair[1])
+		}
+	}
 	return buf
 }

--- a/ceph_test.go
+++ b/ceph_test.go
@@ -15,10 +15,160 @@
 package main
 
 import (
+	"errors"
+	"math"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 )
+
+func TestHasDuplicateOSDID(t *testing.T) {
+	for _, tt := range []struct {
+		name   string
+		osdids []int
+		want   bool
+	}{
+		{
+			name:   "nil slice",
+			osdids: nil,
+			want:   false,
+		},
+		{
+			name:   "empty slice",
+			osdids: []int{},
+			want:   false,
+		},
+		{
+			name:   "single element",
+			osdids: []int{7},
+			want:   false,
+		},
+		{
+			name:   "non duplicate normal values",
+			osdids: []int{1, 2, 3},
+			want:   false,
+		},
+		{
+			name:   "duplicate normal values",
+			osdids: []int{1, 2, 1},
+			want:   true,
+		},
+		{
+			name:   "invalid sentinel only",
+			osdids: []int{invalidOSD, invalidOSD, invalidOSD},
+			want:   false,
+		},
+		{
+			name:   "mixed invalid sentinel and duplicate value",
+			osdids: []int{invalidOSD, 7, invalidOSD, 7},
+			want:   true,
+		},
+		{
+			name:   "negative values no duplicate",
+			osdids: []int{-1, -2, -3},
+			want:   false,
+		},
+		{
+			name:   "negative values with duplicate",
+			osdids: []int{-1, -2, -1},
+			want:   true,
+		},
+		{
+			name:   "large int values with duplicate",
+			osdids: []int{math.MaxInt, 42, math.MaxInt},
+			want:   true,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, hasDuplicateOSDID(tt.osdids))
+		})
+	}
+}
+
+func TestParsePGRemapEntry(t *testing.T) {
+	for _, tt := range []struct {
+		name    string
+		entry   string
+		want    *pgUpmapItem
+		wantErr bool
+	}{
+		{
+			name:  "3-OSD replicated, space-separated brackets",
+			entry: "1.0\t[3, 7, 8] -> [3, 7, 2]",
+			want: &pgUpmapItem{
+				PgID: "1.0",
+				Mappings: []mapping{
+					{From: 3, To: 3},
+					{From: 7, To: 7},
+					{From: 8, To: 2},
+				},
+			},
+		},
+		{
+			name:  "tab-separated brackets, multi-digit OSD IDs",
+			entry: "1.abc\t[1, 22, 333] -> [1, 44, 333]",
+			want: &pgUpmapItem{
+				PgID: "1.abc",
+				Mappings: []mapping{
+					{From: 1, To: 1},
+					{From: 22, To: 44},
+					{From: 333, To: 333},
+				},
+			},
+		},
+		{
+			name:  "single-OSD mapping",
+			entry: "2.f [5] -> [9]",
+			want: &pgUpmapItem{
+				PgID: "2.f",
+				Mappings: []mapping{
+					{From: 5, To: 9},
+				},
+			},
+		},
+		{
+			name:  "all same (no actual remap)",
+			entry: "3.1 [1, 2] -> [1, 2]",
+			want: &pgUpmapItem{
+				PgID: "3.1",
+				Mappings: []mapping{
+					{From: 1, To: 1},
+					{From: 2, To: 2},
+				},
+			},
+		},
+		{
+			name:    "missing arrow / incomplete",
+			entry:   "1.0 [3, 7, 8]",
+			wantErr: true,
+		},
+		{
+			name:    "no space after pgid",
+			entry:   "nospace",
+			wantErr: true,
+		},
+		{
+			name:    "mismatched lhs/rhs count",
+			entry:   "1.0 [3, 7] -> [3, 7, 2]",
+			wantErr: true,
+		},
+		{
+			name:    "empty lhs",
+			entry:   "1.0 [] -> [3]",
+			wantErr: true,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parsePGRemapEntry(tt.entry)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
 
 func TestParseCrushDiff(t *testing.T) {
 	for _, tt := range []struct {
@@ -96,7 +246,7 @@ osdmaptool: osdmap file '/tmp/tmp5ip_axby/osdmap'
 2.0	[4, 5, 8] -> [3, 6]
 		`,
 			items:  nil,
-			errMsg: "could not parse PG mapping entry: invalid PG mapping entry",
+			errMsg: "could not parse PG mapping entry: unequal count between existing and new OSD sets within mapping",
 		},
 		{
 			name: "invalid case with 1 PG with mismatched From set",
@@ -123,7 +273,7 @@ osdmaptool: osdmap file '/tmp/tmp5ip_axby/osdmap'
 2.0	[4, 5] -> [3, 6, 0]
 		`,
 			items:  nil,
-			errMsg: "could not parse PG mapping entry: invalid PG mapping entry",
+			errMsg: "could not parse PG mapping entry: unequal count between existing and new OSD sets within mapping",
 		},
 		{
 			name: "invalid case with 1 PG with both mismatched sets",
@@ -169,8 +319,272 @@ osdmaptool: osdmap file '/tmp/tmp5ip_axby/osdmap'
 			}
 
 			items, err := crushCmp("")
-			require.Nil(t, err)
-			require.Equal(t, items, tt.items)
+			require.NoError(t, err)
+			require.Equal(t, tt.items, items)
 		})
 	}
+}
+
+func TestParseCrushDiffSortsAndKeepsLastDuplicate(t *testing.T) {
+	input := `
+2.0	[4, 5, 8] -> [3, 6, 0]
+1.0	[3, 7, 8] -> [3, 7, 2]
+2.0	[4, 5, 8] -> [4, 6, 0]
+`
+
+	puis, err := parseCrushDiff(input)
+	require.NoError(t, err)
+	require.Len(t, puis, 2)
+
+	// Output should always be sorted by PG ID.
+	require.Equal(t, "1.0", puis[0].PgID)
+	require.Equal(t, []mapping{{From: 3, To: 3}, {From: 7, To: 7}, {From: 8, To: 2}}, puis[0].Mappings)
+
+	require.Equal(t, "2.0", puis[1].PgID)
+	// Duplicate PG ID should keep the last parsed mapping entry.
+	require.Equal(t, []mapping{{From: 4, To: 4}, {From: 5, To: 6}, {From: 8, To: 0}}, puis[1].Mappings)
+}
+
+func TestParseCrushDiffMonotonicInputKeepsLastDuplicate(t *testing.T) {
+	input := `
+1.0	[3, 7, 8] -> [3, 7, 2]
+1.0	[3, 7, 8] -> [3, 2, 8]
+2.0	[4, 5, 8] -> [3, 6, 0]
+`
+
+	puis, err := parseCrushDiff(input)
+	require.NoError(t, err)
+	require.Len(t, puis, 2)
+
+	require.Equal(t, "1.0", puis[0].PgID)
+	// Duplicate PG ID should keep the last parsed mapping entry.
+	require.Equal(t, []mapping{{From: 3, To: 3}, {From: 7, To: 2}, {From: 8, To: 8}}, puis[0].Mappings)
+
+	require.Equal(t, "2.0", puis[1].PgID)
+	require.Equal(t, []mapping{{From: 4, To: 3}, {From: 5, To: 6}, {From: 8, To: 0}}, puis[1].Mappings)
+}
+
+func resetCephStateForCacheTest() {
+	savedOsdDumpOut = nil
+	savedOsdPoolsDetails = nil
+	savedParsedOsdTree = nil
+	savedPgDumpPgsBrief = nil
+	savedPgUpmapItemMap = nil
+	savedPgUpmapItemMapSource = nil
+}
+
+func TestPgUpmapItemMapCacheInvalidatesAfterOsdDumpReset(t *testing.T) {
+	resetCephStateForCacheTest()
+	defer teardownTest(t)
+
+	variant := 1
+	runOsdDump = func() (string, error) {
+		if variant == 1 {
+			return `{"pg_upmap_items":[{"pgid":"1.1","mappings":[{"from":10,"to":11}]}]}`, nil
+		}
+		return `{"pg_upmap_items":[{"pgid":"1.2","mappings":[{"from":20,"to":21}]}]}`, nil
+	}
+
+	first := pgUpmapItemMap()
+	require.Contains(t, first, "1.1")
+	require.NotContains(t, first, "1.2")
+
+	variant = 2
+
+	// Without resetting osdDump cache, map should still be the same cached view.
+	second := pgUpmapItemMap()
+	require.Equal(t, first, second)
+	require.Contains(t, second, "1.1")
+	require.NotContains(t, second, "1.2")
+
+	// Resetting osdDump cache should force a fresh map build from new dump content.
+	savedOsdDumpOut = nil
+	third := pgUpmapItemMap()
+	require.NotEqual(t, first, third)
+	require.Contains(t, third, "1.2")
+	require.NotContains(t, third, "1.1")
+}
+
+func TestPgDumpPgsBriefReordersUsingUpmapMappings(t *testing.T) {
+	resetCephStateForCacheTest()
+	defer teardownTest(t)
+
+	runOsdPoolLs = func() (string, error) {
+		return `[
+			{"pool_id": 1, "pool_name": "replicated", "erasure_code_profile": ""}
+		]`, nil
+	}
+	runOsdDump = func() (string, error) {
+		return `{
+			"pg_upmap_items": [
+				{"pgid":"1.1","mappings":[{"from":4,"to":2}]},
+				{"pgid":"1.2","mappings":[{"from":8,"to":6}]}
+			]
+		}`, nil
+	}
+	runPgDumpPgsBrief = func() (string, error) {
+		return `[
+			{"pgid":"1.1","state":"active","up":[1,3,2],"acting":[1,4,3]},
+			{"pgid":"1.2","state":"active","up":[5,7,6],"acting":[5,8,7]}
+		]`, nil
+	}
+
+	pgBriefs := pgDumpPgsBrief()
+	require.Len(t, pgBriefs, 2)
+	require.Equal(t, []int{1, 2, 3}, pgBriefs[0].Up)
+	require.Equal(t, []int{5, 6, 7}, pgBriefs[1].Up)
+}
+
+func TestPgDumpPgsBriefDoesNotReorderECPools(t *testing.T) {
+	resetCephStateForCacheTest()
+	defer teardownTest(t)
+
+	runOsdPoolLs = func() (string, error) {
+		return `[
+			{"pool_id": 2, "pool_name": "ec", "erasure_code_profile": "ec-profile"}
+		]`, nil
+	}
+	runOsdDump = func() (string, error) {
+		return `{
+			"pg_upmap_items": [
+				{"pgid":"2.1","mappings":[{"from":4,"to":2}]}
+			]
+		}`, nil
+	}
+	runPgDumpPgsBrief = func() (string, error) {
+		return `[
+			{"pgid":"2.1","state":"active","up":[1,3,2],"acting":[1,4,3]}
+		]`, nil
+	}
+
+	pgBriefs := pgDumpPgsBrief()
+	require.Len(t, pgBriefs, 1)
+	// EC pool ordering must be preserved exactly.
+	require.Equal(t, []int{1, 3, 2}, pgBriefs[0].Up)
+}
+
+func TestPgDumpPgsBriefParsesBothJSONShapes(t *testing.T) {
+	tests := []struct {
+		name string
+		out  string
+	}{
+		{
+			name: "array",
+			out: `[
+				{"pgid":"1.1","state":"active","up":[1,2,3],"acting":[1,2,3]},
+				{"pgid":"1.2","state":"active","up":[4,5,6],"acting":[4,5,6]}
+			]`,
+		},
+		{
+			name: "nautilus+",
+			out: `{
+				"pg_stats": [
+					{"pgid":"1.1","state":"active","up":[1,2,3],"acting":[1,2,3]},
+					{"pgid":"1.2","state":"active","up":[4,5,6],"acting":[4,5,6]}
+				]
+			}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resetCephStateForCacheTest()
+			defer teardownTest(t)
+
+			runOsdPoolLs = func() (string, error) {
+				return `[
+					{"pool_id": 1, "pool_name": "replicated", "erasure_code_profile": ""}
+				]`, nil
+			}
+			runOsdDump = func() (string, error) {
+				return `{"pg_upmap_items": []}`, nil
+			}
+			runPgDumpPgsBrief = func() (string, error) {
+				return tt.out, nil
+			}
+
+			pgBriefs := pgDumpPgsBrief()
+			require.Len(t, pgBriefs, 2)
+			require.Equal(t, "1.1", pgBriefs[0].PgID)
+			require.Equal(t, "1.2", pgBriefs[1].PgID)
+		})
+	}
+}
+
+func TestParseCephCommandAndHandleCephInf(t *testing.T) {
+	t.Run("valid JSON", func(t *testing.T) {
+		var out struct {
+			X int `json:"x"`
+		}
+		err := parseCephCommand(`{"x":7}`, nil, &out)
+		require.NoError(t, err)
+		require.Equal(t, 7, out.X)
+	})
+
+	t.Run("run error returned", func(t *testing.T) {
+		var out map[string]any
+		err := parseCephCommand(`{"x":7}`, errors.New("boom"), &out)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "boom")
+	})
+
+	t.Run("inf replacement", func(t *testing.T) {
+		in := []byte(`{"a": inf, "b":inf, "c": 1}`)
+		got := handleCephInf(in)
+		require.Equal(t, `{"a": null, "b":null, "c": 1}`, string(got))
+	})
+
+	t.Run("no inf", func(t *testing.T) {
+		in := []byte(`{"a": 1, "b": 2}`)
+		got := handleCephInf(in)
+		require.Equal(t, string(in), string(got))
+	})
+
+	t.Run("does not replace non-matching inf text", func(t *testing.T) {
+		in := []byte(`{"a":"infinite", "b":"prefix_inf_suffix"}`)
+		got := handleCephInf(in)
+		require.Equal(t, string(in), string(got))
+	})
+
+	t.Run("replaces multiple spaced and compact inf occurrences", func(t *testing.T) {
+		in := []byte(`{"a": inf, "b":inf, "c": inf, "d":inf}`)
+		got := handleCephInf(in)
+		require.Equal(t, `{"a": null, "b":null, "c": null, "d":null}`, string(got))
+	})
+}
+
+func TestGetOsdsForBucketNotFoundAndDeviceClassFilter(t *testing.T) {
+	t.Run("not found", func(t *testing.T) {
+		setupTest(t)
+		t.Cleanup(func() { teardownTest(t) })
+
+		runOsdTree = func() (string, error) {
+			return `{"nodes":[]}`, nil
+		}
+
+		_, err := getOsdsForBucket("does-not-exist", "")
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "not a CRUSH bucket")
+	})
+
+	t.Run("device class filtering", func(t *testing.T) {
+		setupTest(t)
+		t.Cleanup(func() { teardownTest(t) })
+
+		runOsdTree = func() (string, error) {
+			return `{
+				"nodes": [
+					{"id":-1, "name":"root", "type":"root", "children":[-2]},
+					{"id":-2, "name":"rack1", "type":"rack", "children":[0,1,2]},
+					{"id":0, "name":"osd.0", "type":"osd", "device_class":"hdd", "reweight":1},
+					{"id":1, "name":"osd.1", "type":"osd", "device_class":"ssd", "reweight":1},
+					{"id":2, "name":"osd.2", "type":"osd", "device_class":"ssd", "reweight":0}
+				]
+			}`, nil
+		}
+
+		osds, err := getOsdsForBucket("rack1", "ssd")
+		require.NoError(t, err)
+		require.Equal(t, []int{1}, osds)
+	})
 }

--- a/main.go
+++ b/main.go
@@ -24,7 +24,6 @@ import (
 	"os/exec"
 	"runtime/debug"
 	"slices"
-	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -595,7 +594,7 @@ func mustParseOsdSpec(s string) []int {
 
 func parseOsdSpec(s string) ([]int, error) {
 	errResponse := func(s string) ([]int, error) {
-		return nil, errors.New(fmt.Sprintf("'%s' is not a valid osdspec - see root command --help", s))
+		return nil, fmt.Errorf("'%s' is not a valid osdspec - see root command --help", s)
 	}
 
 	osd, err := strconv.Atoi(s)
@@ -603,16 +602,16 @@ func parseOsdSpec(s string) ([]int, error) {
 		return []int{osd}, nil
 	}
 
-	spl := strings.SplitN(s, ":", 2)
-	if len(spl) != 2 {
+	prefix, bucketName, ok := strings.Cut(s, ":")
+	if !ok {
 		return errResponse(s)
 	}
 
-	if spl[0] != "bucket" {
+	if prefix != "bucket" {
 		return errResponse(s)
 	}
 
-	osds, err := getOsdsForBucket(spl[1], "")
+	osds, err := getOsdsForBucket(bucketName, "")
 	if err != nil {
 		return nil, err
 	}
@@ -676,17 +675,18 @@ func mustParseMaxBackfillReservations(cmd *cobra.Command) {
 		M.bs.maxBackfillReservations = max
 
 		for _, s := range strs[1:] {
-			spl := strings.Split(s, ":")
-			if len(spl) < 2 {
-				panic(errors.WithStack(errors.New(fmt.Sprintf("'%s' is not a valid max-backfill-reservation specifier", s))))
+			// Find the last ':' to split osdspec and max value without allocating a split slice.
+			idx := strings.LastIndex(s, ":")
+			if idx < 0 {
+				panic(errors.WithStack(fmt.Errorf("'%s' is not a valid max-backfill-reservation specifier", s)))
 			}
 
-			max, err := strconv.Atoi(spl[len(spl)-1])
+			max, err := strconv.Atoi(s[idx+1:])
 			if err != nil {
 				panic(errors.WithStack(err))
 			}
 
-			osds := mustParseOsdSpec(s[0:strings.LastIndex(s, ":")])
+			osds := mustParseOsdSpec(s[:idx])
 			for _, osd := range osds {
 				M.bs.osd(osd).maxBackfillReservations = max
 			}
@@ -764,10 +764,29 @@ func calcPgMappingsToUndoBackfill(excludeBackfilling, source, target bool, exclu
 		return len(includedOsds) == 0 || ok
 	}
 
+	type remapRequest struct {
+		pgid string
+		from int
+		to   int
+	}
+
 	// Run these concurrently in case they need to go to pgQuery, which is
 	// quite slow.
 	wg := sync.WaitGroup{}
 	ch := make(chan *pgBriefItem)
+
+	// Apply remaps through a single goroutine so mapping state mutations keep
+	// the same semantics while removing producer-side lock contention.
+	remapCh := make(chan remapRequest, concurrency*64)
+	remapDone := make(chan struct{})
+	go func() {
+		defer close(remapDone)
+		for r := range remapCh {
+			if err := M.tryRemap(r.pgid, r.from, r.to); err != nil {
+				fmt.Printf("WARNING: %v\n", err)
+			}
+		}
+	}()
 
 	for i := 0; i < concurrency; i++ {
 		wg.Go(func() {
@@ -775,7 +794,14 @@ func calcPgMappingsToUndoBackfill(excludeBackfilling, source, target bool, exclu
 				id := pgb.PgID
 				up := pgb.Up
 				acting := pgb.Acting
-				pool, err := strconv.Atoi(strings.Split(id, ".")[0])
+				// PGIDs are "<pool>.<suffix>"; find the separator once so we
+				// can parse just the pool prefix without allocating a split slice.
+				m := strings.IndexByte(id, '.')
+				if m <= 0 {
+					fmt.Printf("Could not parse pool ID from PG %s\n", id)
+					continue
+				}
+				pool, err := strconv.Atoi(id[:m])
 				if err != nil {
 					fmt.Printf("Could not parse pool ID from PG %s: %s\n", id, err)
 					continue
@@ -811,10 +837,18 @@ func calcPgMappingsToUndoBackfill(excludeBackfilling, source, target bool, exclu
 
 				if len(pgsIncludingOsds) > 0 {
 					include := false
-					for _, osd := range append(acting, up...) {
+					for _, osd := range acting {
 						if _, ok := pgsIncludingOsds[osd]; ok {
 							include = true
 							break
+						}
+					}
+					if !include {
+						for _, osd := range up {
+							if _, ok := pgsIncludingOsds[osd]; ok {
+								include = true
+								break
+							}
 						}
 					}
 					if !include {
@@ -871,9 +905,10 @@ func calcPgMappingsToUndoBackfill(excludeBackfilling, source, target bool, exclu
 						// actually use the upmap
 						// exception table to cancel
 						// the backfill.
-						err := M.tryRemap(id, up[i], acting[i])
-						if err != nil {
-							fmt.Printf("WARNING: %v\n", err)
+						remapCh <- remapRequest{
+							pgid: id,
+							from: up[i],
+							to:   acting[i],
 						}
 					}
 				}
@@ -888,6 +923,8 @@ func calcPgMappingsToUndoBackfill(excludeBackfilling, source, target bool, exclu
 
 	close(ch)
 	wg.Wait()
+	close(remapCh)
+	<-remapDone
 }
 
 func calcPgMappingsToDrainOsd(
@@ -895,6 +932,9 @@ func calcPgMappingsToDrainOsd(
 	sourceOsds []int,
 	targetOsds map[int]struct{},
 ) {
+	// targetOsds does not change in this function; materialize once.
+	targetOsdList := mapKeysInt(targetOsds)
+
 	changed := true
 	for changed {
 		changed = false
@@ -902,7 +942,7 @@ func calcPgMappingsToDrainOsd(
 			candidateMappings := getCandidateMappings(
 				allowMovementAcrossCrushType,
 				sourceOsd,
-				mapKeysInt(targetOsds),
+				targetOsdList,
 			)
 
 			if len(candidateMappings) > 0 {
@@ -920,15 +960,20 @@ func getCandidateMappings(
 	sourceOsd int,
 	targetOsds []int,
 ) []pgMapping {
+	tree := osdTree()
+	sourceOsdNode := tree.IDToNode[sourceOsd]
 	pgs := getUpPGsForOsds([]int{sourceOsd})
-	candidateMappings := []pgMapping{}
-	for _, pg := range pgs[sourceOsd] {
+	sourcePGs := pgs[sourceOsd]
+	candidateMappings := make([]pgMapping, 0, len(sourcePGs)*len(targetOsds))
+	for _, pg := range sourcePGs {
 		for _, targetOsd := range targetOsds {
 			if !isCandidateMapping(
 				allowMovementAcrossCrushType,
 				sourceOsd,
 				targetOsd,
 				pg,
+				tree,
+				sourceOsdNode,
 			) {
 				continue
 			}
@@ -949,13 +994,12 @@ func isCandidateMapping(
 	sourceOsd int,
 	targetOsd int,
 	pg *pgBriefItem,
+	tree *parsedOsdTree,
+	sourceOsdNode *osdTreeNode,
 ) bool {
 	if targetOsd == sourceOsd {
 		return false
 	}
-
-	tree := osdTree()
-	sourceOsdNode := tree.IDToNode[sourceOsd]
 	targetOsdNode := tree.IDToNode[targetOsd]
 
 	if allowMovementAcrossCrushType == "" {
@@ -1221,7 +1265,7 @@ func mapKeysInt(mm map[int]struct{}) []int {
 	for k := range mm {
 		ret = append(ret, k)
 	}
-	sort.Ints(ret)
+	slices.Sort(ret)
 	return ret
 }
 

--- a/main_test.go
+++ b/main_test.go
@@ -15,8 +15,12 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
 	"math/rand"
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/spf13/cobra"
@@ -308,7 +312,7 @@ func TestCalcPgMappingsToUndoBackfill(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			setupTest(t)
-			defer teardownTest(t)
+			t.Cleanup(func() { teardownTest(t) })
 
 			runOsdDump = func() (string, error) { return osdDumpOut, nil }
 			runPgDumpPgsBrief = func() (string, error) { return pgDumpOut, nil }
@@ -351,9 +355,59 @@ func TestCalcPgMappingsToUndoBackfill(t *testing.T) {
 	}
 }
 
+func TestCalcPgMappingsToUndoBackfillAppliesAllQueuedRemapsBeforeReturn(t *testing.T) {
+	setupTest(t)
+	t.Cleanup(func() { teardownTest(t) })
+
+	const pgCount = 200
+	var sb strings.Builder
+	sb.WriteString("[\n")
+	for i := range pgCount {
+		if i > 0 {
+			sb.WriteString(",\n")
+		}
+		fmt.Fprintf(
+			&sb,
+			` { "pgid": "1.%x", "up": [ 1, 100, 3 ], "acting": [ 1, 101, 3 ], "state": "backfill_wait" }`,
+			i,
+		)
+	}
+	sb.WriteString("\n]\n")
+	pgDumpOut := sb.String()
+
+	runOsdDump = func() (string, error) {
+		return `{"pg_upmap_items":[]}`, nil
+	}
+	runPgDumpPgsBrief = func() (string, error) {
+		return pgDumpOut, nil
+	}
+
+	prevConcurrency := concurrency
+	concurrency = 1
+	t.Cleanup(func() { concurrency = prevConcurrency })
+
+	M = mustGetCurrentMappingState()
+	calcPgMappingsToUndoBackfill(
+		true, // excludeBackfilling
+		false,
+		false,
+		map[int]struct{}{},
+		map[int]struct{}{},
+		map[int]struct{}{},
+		map[int]struct{}{},
+		map[int]struct{}{},
+	)
+
+	puis := M.dirtyUpmapItems()
+	require.Len(t, puis, pgCount)
+	for _, pui := range puis {
+		require.Equal(t, []mapping{{From: 100, To: 101, dirty: true}}, pui.Mappings)
+	}
+}
+
 func TestCountCurrentBackfills(t *testing.T) {
 	setupTest(t)
-	defer teardownTest(t)
+	t.Cleanup(func() { teardownTest(t) })
 	out := `
 [
  { "pgid": "1.32", "up": [ 7, 5, 9], "acting": [ 7, 5, 9 ] },
@@ -449,7 +503,7 @@ func TestCalcPgMappingsToUndoUpmaps(t *testing.T) {
 
 	t.Run("source OSDs specified", func(t *testing.T) {
 		setupTest(t)
-		defer teardownTest(t)
+		t.Cleanup(func() { teardownTest(t) })
 
 		runOsdDump = func() (string, error) { return osdDumpOut, nil }
 		runPgDumpPgsBrief = func() (string, error) { return pgDumpOut, nil }
@@ -472,7 +526,7 @@ func TestCalcPgMappingsToUndoUpmaps(t *testing.T) {
 
 	t.Run("target OSDs specified", func(t *testing.T) {
 		setupTest(t)
-		defer teardownTest(t)
+		t.Cleanup(func() { teardownTest(t) })
 
 		runOsdDump = func() (string, error) { return osdDumpOut, nil }
 		runPgDumpPgsBrief = func() (string, error) { return pgDumpOut, nil }
@@ -493,7 +547,7 @@ func TestCalcPgMappingsToUndoUpmaps(t *testing.T) {
 
 	t.Run("max-backfills specified", func(t *testing.T) {
 		setupTest(t)
-		defer teardownTest(t)
+		t.Cleanup(func() { teardownTest(t) })
 
 		runOsdDump = func() (string, error) { return osdDumpOut, nil }
 		runPgDumpPgsBrief = func() (string, error) { return pgDumpOut, nil }
@@ -601,7 +655,7 @@ func TestCalcPgMappingsToBalanceHost(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			setupTest(t)
-			defer teardownTest(t)
+			t.Cleanup(func() { teardownTest(t) })
 
 			runOsdDump = func() (string, error) { return osdDumpOut, nil }
 			runPgDumpPgsBrief = func() (string, error) { return pgDumpOut, nil }
@@ -826,7 +880,7 @@ func TestCalcPgMappingsToDrainOsd(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			setupTest(t)
-			defer teardownTest(t)
+			t.Cleanup(func() { teardownTest(t) })
 
 			runOsdDump = func() (string, error) { return osdDumpOut, nil }
 			runOsdTree = func() (string, error) { return osdTreeOut, nil }
@@ -859,6 +913,7 @@ type expectedMapping struct {
 }
 
 func validateDirtyMappings(t *testing.T, expected []expectedMapping) {
+	t.Helper()
 	puis := M.dirtyUpmapItems()
 	require.Len(t, puis, len(expected))
 
@@ -870,7 +925,7 @@ func validateDirtyMappings(t *testing.T, expected []expectedMapping) {
 
 func TestParseMaxBackfillReservations(t *testing.T) {
 	setupTest(t)
-	defer teardownTest(t)
+	t.Cleanup(func() { teardownTest(t) })
 	osdTreeOut := `
 {
   "nodes": [
@@ -901,9 +956,35 @@ func TestParseMaxBackfillReservations(t *testing.T) {
 	require.Equal(t, 6, M.bs.getMaxBackfillReservations(133))
 }
 
+func TestParseMaxBackfillReservationsInvalidSpecifier(t *testing.T) {
+	setupTest(t)
+	t.Cleanup(func() { teardownTest(t) })
+
+	runOsdDump = func() (string, error) { return `{"osds":[],"pg_upmap_items":[]}`, nil }
+	runPgDumpPgsBrief = func() (string, error) { return `[]`, nil }
+	runOsdPoolLs = func() (string, error) {
+		return `[{"pool_id":1,"pool_name":"replicated","erasure_code_profile":""}]`, nil
+	}
+
+	cmd := &cobra.Command{}
+	cmd.Flags().StringSlice("max-backfill-reservations", []string{"4", "invalidspec"}, "")
+
+	M = mustGetCurrentMappingState()
+
+	defer func() {
+		msg := recover()
+		require.NotNil(t, msg)
+		e, ok := msg.(error)
+		require.True(t, ok)
+		require.Contains(t, e.Error(), "is not a valid max-backfill-reservation specifier")
+	}()
+
+	mustParseMaxBackfillReservations(cmd)
+}
+
 func TestDeviceClassFilter(t *testing.T) {
 	setupTest(t)
-	defer teardownTest(t)
+	t.Cleanup(func() { teardownTest(t) })
 	osdTreeOut := `
 	{
 		"nodes": [
@@ -941,7 +1022,508 @@ func TestDeviceClassFilter(t *testing.T) {
 		[]int{9, 10, 11})
 }
 
+func TestImportMappingsFromFileAppliesMappings(t *testing.T) {
+	setupTest(t)
+	t.Cleanup(func() { teardownTest(t) })
+
+	logPath := installFakeCeph(t)
+
+	runOsdDump = func() (string, error) { return `{"pg_upmap_items":[]}`, nil }
+	runPgDumpPgsBrief = func() (string, error) {
+		return `[
+			{"pgid":"1.1","state":"active+clean","up":[1,2,3],"acting":[1,2,3]}
+		]`, nil
+	}
+
+	inputPath := filepath.Join(t.TempDir(), "import.json")
+	input := []pgMapping{{PgID: "1.1", Mapping: mapping{From: 1, To: 4}}}
+	b, err := json.Marshal(input)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(inputPath, b, 0o600))
+
+	prevYes := yes
+	yes = true
+	t.Cleanup(func() { yes = prevYes })
+
+	importMappingsCommand.Run(importMappingsCommand, []string{inputPath})
+
+	logOut, err := os.ReadFile(logPath)
+	require.NoError(t, err)
+	require.Contains(t, string(logOut), "osd pg-upmap-items 1.1 1 4")
+}
+
+func TestImportMappingsFromStdinAppliesMappings(t *testing.T) {
+	setupTest(t)
+	t.Cleanup(func() { teardownTest(t) })
+
+	logPath := installFakeCeph(t)
+
+	runOsdDump = func() (string, error) { return `{"pg_upmap_items":[]}`, nil }
+	runPgDumpPgsBrief = func() (string, error) {
+		return `[
+			{"pgid":"1.1","state":"active+clean","up":[1,2,3],"acting":[1,2,3]}
+		]`, nil
+	}
+
+	stdinPath := filepath.Join(t.TempDir(), "stdin.json")
+	input := []pgMapping{{PgID: "1.1", Mapping: mapping{From: 2, To: 9}}}
+	b, err := json.Marshal(input)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(stdinPath, b, 0o600))
+
+	f, err := os.Open(stdinPath)
+	require.NoError(t, err)
+	defer f.Close()
+
+	oldStdin := os.Stdin
+	os.Stdin = f
+	t.Cleanup(func() { os.Stdin = oldStdin })
+
+	prevYes := yes
+	yes = true
+	t.Cleanup(func() { yes = prevYes })
+
+	importMappingsCommand.Run(importMappingsCommand, nil)
+
+	logOut, err := os.ReadFile(logPath)
+	require.NoError(t, err)
+	require.Contains(t, string(logOut), "osd pg-upmap-items 1.1 2 9")
+}
+
+func TestImportMappingsModifiesExistingFromMapping(t *testing.T) {
+	setupTest(t)
+	t.Cleanup(func() { teardownTest(t) })
+
+	logPath := installFakeCeph(t)
+
+	runOsdDump = func() (string, error) {
+		return `{
+			"pg_upmap_items":[
+				{"pgid":"1.1","mappings":[{"from":1,"to":3}]}
+			]
+		}`, nil
+	}
+	runPgDumpPgsBrief = func() (string, error) {
+		return `[
+			{"pgid":"1.1","state":"active+remapped","up":[3,2,4],"acting":[1,2,4]}
+		]`, nil
+	}
+
+	inputPath := filepath.Join(t.TempDir(), "import.json")
+	input := []pgMapping{{PgID: "1.1", Mapping: mapping{From: 1, To: 8}}}
+	b, err := json.Marshal(input)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(inputPath, b, 0o600))
+
+	prevYes := yes
+	yes = true
+	t.Cleanup(func() { yes = prevYes })
+
+	importMappingsCommand.Run(importMappingsCommand, []string{inputPath})
+
+	logOut, err := os.ReadFile(logPath)
+	require.NoError(t, err)
+	require.Contains(t, string(logOut), "osd pg-upmap-items 1.1 1 8")
+}
+
+func TestImportMappingsConfirmProceedFalseDoesNotApply(t *testing.T) {
+	setupTest(t)
+	t.Cleanup(func() { teardownTest(t) })
+
+	logPath := installFakeCeph(t)
+
+	runOsdDump = func() (string, error) { return `{"pg_upmap_items":[]}`, nil }
+	runPgDumpPgsBrief = func() (string, error) {
+		return `[
+			{"pgid":"1.1","state":"active+clean","up":[1,2,3],"acting":[1,2,3]}
+		]`, nil
+	}
+
+	inputPath := filepath.Join(t.TempDir(), "import.json")
+	input := []pgMapping{{PgID: "1.1", Mapping: mapping{From: 1, To: 4}}}
+	b, err := json.Marshal(input)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(inputPath, b, 0o600))
+
+	prevYes := yes
+	yes = false
+	t.Cleanup(func() { yes = prevYes })
+
+	importMappingsCommand.Run(importMappingsCommand, []string{inputPath})
+
+	logOut, err := os.ReadFile(logPath)
+	require.NoError(t, err)
+	require.Empty(t, strings.TrimSpace(string(logOut)))
+	require.NotEmpty(t, M.dirtyUpmapItems())
+}
+
+func TestExportMappingsWritesSelectedMappings(t *testing.T) {
+	setupTest(t)
+	t.Cleanup(func() { teardownTest(t) })
+
+	runOsdDump = func() (string, error) {
+		return `{
+			"pg_upmap_items":[
+				{"pgid":"1.1","mappings":[{"from":1,"to":4},{"from":6,"to":7}]},
+				{"pgid":"1.2","mappings":[{"from":3,"to":1}]}
+			]
+		}`, nil
+	}
+	runPgDumpPgsBrief = func() (string, error) {
+		return `[
+			{"pgid":"1.1","state":"active","up":[4,7,8],"acting":[1,6,8]},
+			{"pgid":"1.2","state":"active","up":[1,5,9],"acting":[3,5,9]}
+		]`, nil
+	}
+
+	outputPath := filepath.Join(t.TempDir(), "out.json")
+	require.NoError(t, exportMappingsCommand.Flags().Set("output", outputPath))
+	require.NoError(t, exportMappingsCommand.Flags().Set("whole-pg", "false"))
+
+	exportMappingsCommand.Run(exportMappingsCommand, []string{"1"})
+
+	out, err := os.ReadFile(outputPath)
+	require.NoError(t, err)
+	var got []pgMapping
+	require.NoError(t, json.Unmarshal(out, &got))
+
+	require.ElementsMatch(t, []pgMapping{
+		{PgID: "1.1", Mapping: mapping{From: 1, To: 4}},
+		{PgID: "1.2", Mapping: mapping{From: 3, To: 1}},
+	}, got)
+}
+
+func TestExportMappingsWholePgIncludesAllMappingsForMatchedPGs(t *testing.T) {
+	setupTest(t)
+	t.Cleanup(func() { teardownTest(t) })
+
+	runOsdDump = func() (string, error) {
+		return `{
+			"pg_upmap_items":[
+				{"pgid":"1.1","mappings":[{"from":1,"to":4},{"from":6,"to":7}]},
+				{"pgid":"1.2","mappings":[{"from":3,"to":9}]}
+			]
+		}`, nil
+	}
+	runPgDumpPgsBrief = func() (string, error) {
+		return `[
+			{"pgid":"1.1","state":"active","up":[4,7,8],"acting":[1,6,8]},
+			{"pgid":"1.2","state":"active","up":[9,5,2],"acting":[3,5,2]}
+		]`, nil
+	}
+
+	outputPath := filepath.Join(t.TempDir(), "out.json")
+	require.NoError(t, exportMappingsCommand.Flags().Set("output", outputPath))
+	require.NoError(t, exportMappingsCommand.Flags().Set("whole-pg", "true"))
+
+	exportMappingsCommand.Run(exportMappingsCommand, []string{"1"})
+
+	out, err := os.ReadFile(outputPath)
+	require.NoError(t, err)
+	var got []pgMapping
+	require.NoError(t, json.Unmarshal(out, &got))
+
+	require.ElementsMatch(t, []pgMapping{
+		{PgID: "1.1", Mapping: mapping{From: 1, To: 4}},
+		{PgID: "1.1", Mapping: mapping{From: 6, To: 7}},
+	}, got)
+}
+
+func TestExportMappingsOutputFileCreatesValidJSON(t *testing.T) {
+	setupTest(t)
+	t.Cleanup(func() { teardownTest(t) })
+
+	runOsdDump = func() (string, error) { return `{"pg_upmap_items":[]}`, nil }
+	runPgDumpPgsBrief = func() (string, error) { return `[]`, nil }
+
+	outputPath := filepath.Join(t.TempDir(), "out.json")
+	require.NoError(t, exportMappingsCommand.Flags().Set("output", outputPath))
+	require.NoError(t, exportMappingsCommand.Flags().Set("whole-pg", "false"))
+
+	exportMappingsCommand.Run(exportMappingsCommand, []string{"1"})
+
+	out, err := os.ReadFile(outputPath)
+	require.NoError(t, err)
+	var got []pgMapping
+	require.NoError(t, json.Unmarshal(out, &got))
+	require.Empty(t, got)
+}
+
+func TestParseOsdSpec(t *testing.T) {
+	t.Run("osd id", func(t *testing.T) {
+		setupTest(t)
+		t.Cleanup(func() { teardownTest(t) })
+
+		osds, err := parseOsdSpec("42")
+		require.NoError(t, err)
+		require.Equal(t, []int{42}, osds)
+	})
+
+	t.Run("bucket", func(t *testing.T) {
+		setupTest(t)
+		t.Cleanup(func() { teardownTest(t) })
+
+		runOsdTree = func() (string, error) {
+			return `{
+				"nodes": [
+					{"id":-1, "name":"rack1", "type":"rack", "children":[0,1]},
+					{"id":0, "name":"osd.0", "type":"osd", "reweight":1},
+					{"id":1, "name":"osd.1", "type":"osd", "reweight":1}
+				]
+			}`, nil
+		}
+
+		osds, err := parseOsdSpec("bucket:rack1")
+		require.NoError(t, err)
+		require.ElementsMatch(t, []int{0, 1}, osds)
+	})
+
+	t.Run("invalid format and prefix", func(t *testing.T) {
+		setupTest(t)
+		t.Cleanup(func() { teardownTest(t) })
+
+		_, err := parseOsdSpec("not-a-spec")
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "not a valid osdspec")
+
+		_, err = parseOsdSpec("pool:rack1")
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "not a valid osdspec")
+	})
+}
+
+func TestParsePoolSpec(t *testing.T) {
+	setupTest(t)
+	t.Cleanup(func() { teardownTest(t) })
+
+	runOsdPoolLs = func() (string, error) {
+		return `[
+			{"pool_id":1, "pool_name":"replicated", "erasure_code_profile":""},
+			{"pool_id":7, "pool_name":"rbd", "erasure_code_profile":""}
+		]`, nil
+	}
+
+	pools, err := parsePoolSpec("7")
+	require.NoError(t, err)
+	require.Equal(t, []int{7}, pools)
+
+	pools, err = parsePoolSpec("rbd")
+	require.NoError(t, err)
+	require.Equal(t, []int{7}, pools)
+
+	_, err = parsePoolSpec("does-not-exist")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "is not a valid pool name or ID")
+}
+
+func TestMustParseMaxSourceBackfillsSetsState(t *testing.T) {
+	setupTest(t)
+	t.Cleanup(func() { teardownTest(t) })
+
+	runPgDumpPgsBrief = func() (string, error) {
+		return `[
+			{"pgid":"1.1","state":"active","up":[1],"acting":[1]}
+		]`, nil
+	}
+
+	cmd := &cobra.Command{}
+	cmd.Flags().Int("max-source-backfills", 17, "")
+
+	M = mustGetCurrentMappingState()
+	mustParseMaxSourceBackfills(cmd)
+	require.Equal(t, 17, M.bs.maxBackfillsFrom)
+}
+
+func TestMustParseMaxBackfillReservationsDefaultOnly(t *testing.T) {
+	setupTest(t)
+	t.Cleanup(func() { teardownTest(t) })
+
+	runPgDumpPgsBrief = func() (string, error) {
+		return `[
+			{"pgid":"1.1","state":"active","up":[1],"acting":[1]}
+		]`, nil
+	}
+
+	cmd := &cobra.Command{}
+	cmd.Flags().StringSlice("max-backfill-reservations", []string{"4"}, "")
+
+	M = mustGetCurrentMappingState()
+	mustParseMaxBackfillReservations(cmd)
+	require.Equal(t, 4, M.bs.maxBackfillReservations)
+}
+
+func TestMustParseMaxBackfillReservationsDefaultAndOverrides(t *testing.T) {
+	setupTest(t)
+	t.Cleanup(func() { teardownTest(t) })
+
+	runOsdTree = func() (string, error) {
+		return `{
+			"nodes": [
+				{"id":-1, "name":"host1", "type":"host", "children":[1,2]},
+				{"id":1, "name":"osd.1", "type":"osd", "reweight":1},
+				{"id":2, "name":"osd.2", "type":"osd", "reweight":1}
+			]
+		}`, nil
+	}
+	runPgDumpPgsBrief = func() (string, error) {
+		return `[
+			{"pgid":"1.1","state":"active","up":[1],"acting":[1]}
+		]`, nil
+	}
+
+	cmd := &cobra.Command{}
+	cmd.Flags().StringSlice("max-backfill-reservations", []string{"4", "bucket:host1:10", "99:6"}, "")
+
+	M = mustGetCurrentMappingState()
+	mustParseMaxBackfillReservations(cmd)
+
+	require.Equal(t, 4, M.bs.maxBackfillReservations)
+	require.Equal(t, 10, M.bs.getMaxBackfillReservations(1))
+	require.Equal(t, 10, M.bs.getMaxBackfillReservations(2))
+	require.Equal(t, 6, M.bs.getMaxBackfillReservations(99))
+}
+
+func TestConfirmProceedStates(t *testing.T) {
+	t.Run("no change", func(t *testing.T) {
+		M = &mappingState{changeState: NoChange}
+		require.False(t, confirmProceed())
+	})
+
+	t.Run("no reservation available", func(t *testing.T) {
+		M = &mappingState{changeState: NoReservationAvailable}
+		require.False(t, confirmProceed())
+	})
+
+	t.Run("yes flag", func(t *testing.T) {
+		prevYes := yes
+		yes = true
+		t.Cleanup(func() { yes = prevYes })
+		M = &mappingState{changeState: ChangesPending}
+		require.True(t, confirmProceed())
+	})
+
+	t.Run("dry run", func(t *testing.T) {
+		prevYes := yes
+		yes = false
+		t.Cleanup(func() { yes = prevYes })
+		M = &mappingState{changeState: ChangesPending}
+		require.False(t, confirmProceed())
+	})
+}
+
+func TestGetCandidateMappingsFiltersInvalidTargets(t *testing.T) {
+	setupTest(t)
+	t.Cleanup(func() { teardownTest(t) })
+
+	runOsdTree = func() (string, error) {
+		return `{
+			"nodes": [
+				{"id":-1, "name":"root", "type":"root", "children":[-2]},
+				{"id":-2, "name":"rack1", "type":"rack", "children":[-3, -4]},
+				{"id":-3, "name":"host1", "type":"host", "children":[0, 1]},
+				{"id":-4, "name":"host2", "type":"host", "children":[2]},
+				{"id":0, "name":"osd.0", "type":"osd", "reweight":1},
+				{"id":1, "name":"osd.1", "type":"osd", "reweight":1},
+				{"id":2, "name":"osd.2", "type":"osd", "reweight":1}
+			]
+		}`, nil
+	}
+	runPgDumpPgsBrief = func() (string, error) {
+		return `[
+			{"pgid":"1.1","state":"active","up":[0],"acting":[0]}
+		]`, nil
+	}
+
+	M = mustGetCurrentMappingState()
+	candidates := getCandidateMappings("", 0, []int{0, 1, 2})
+	require.Equal(t, []pgMapping{{PgID: "1.1", Mapping: mapping{From: 0, To: 1}}}, candidates)
+}
+
+func TestIsCandidateMappingDefaultAndCrossTypeRules(t *testing.T) {
+	setupTest(t)
+	t.Cleanup(func() { teardownTest(t) })
+
+	runOsdTree = func() (string, error) {
+		return `{
+			"nodes": [
+				{"id":-1, "name":"root", "type":"root", "children":[-2, -5]},
+				{"id":-2, "name":"rack1", "type":"rack", "children":[-3, -4]},
+				{"id":-3, "name":"host1", "type":"host", "children":[0]},
+				{"id":-4, "name":"host2", "type":"host", "children":[1,2]},
+				{"id":-5, "name":"rack2", "type":"rack", "children":[-6]},
+				{"id":-6, "name":"host3", "type":"host", "children":[3]},
+				{"id":0, "name":"osd.0", "type":"osd", "reweight":1},
+				{"id":1, "name":"osd.1", "type":"osd", "reweight":1},
+				{"id":2, "name":"osd.2", "type":"osd", "reweight":1},
+				{"id":3, "name":"osd.3", "type":"osd", "reweight":1}
+			]
+		}`, nil
+	}
+
+	tree := osdTree()
+	pg := &pgBriefItem{PgID: "1.1", Up: []int{0, 1}}
+
+	require.False(t, isCandidateMapping("", 0, 0, pg, tree, tree.IDToNode[0]))
+	require.False(t, isCandidateMapping("", 0, 1, pg, tree, tree.IDToNode[0]))
+	require.False(t, isCandidateMapping("", 0, 3, pg, tree, tree.IDToNode[0]))
+
+	pg = &pgBriefItem{PgID: "1.1", Up: []int{0}}
+	require.True(t, isCandidateMapping("host", 0, 1, pg, tree, tree.IDToNode[0]))
+	require.False(t, isCandidateMapping("host", 0, 3, pg, tree, tree.IDToNode[0]))
+}
+
+func TestGetUpPGsForOsdsCollectsMatchingPGs(t *testing.T) {
+	setupTest(t)
+	t.Cleanup(func() { teardownTest(t) })
+
+	runPgDumpPgsBrief = func() (string, error) {
+		return `[
+			{"pgid":"1.1","state":"active","up":[1,2],"acting":[1,2]},
+			{"pgid":"1.2","state":"active","up":[3,4],"acting":[3,4]},
+			{"pgid":"1.3","state":"active","up":[2,5],"acting":[2,5]}
+		]`, nil
+	}
+
+	osdPGs := getUpPGsForOsds([]int{2, 4, 7})
+	require.Len(t, osdPGs[2], 2)
+	require.Equal(t, "1.1", osdPGs[2][0].PgID)
+	require.Equal(t, "1.3", osdPGs[2][1].PgID)
+	require.Len(t, osdPGs[4], 1)
+	require.Equal(t, "1.2", osdPGs[4][0].PgID)
+	require.Len(t, osdPGs[7], 0)
+}
+
+func TestRunCombinedAndRunOrDie(t *testing.T) {
+	out, err := runCombined("sh", "-c", "printf 'ok'")
+	require.NoError(t, err)
+	require.Equal(t, "ok", out)
+
+	require.Panics(t, func() {
+		_ = runOrDie("sh", "-c", "exit 2")
+	})
+}
+
+func installFakeCeph(t *testing.T) string {
+	t.Helper()
+
+	dir := t.TempDir()
+	logPath := filepath.Join(dir, "ceph.log")
+	require.NoError(t, os.WriteFile(logPath, []byte{}, 0o600))
+	cephPath := filepath.Join(dir, "ceph")
+	content := "#!/bin/sh\necho \"$@\" >> \"" + logPath + "\"\nexit 0\n"
+	require.NoError(t, os.WriteFile(cephPath, []byte(content), 0o755))
+
+	oldPath := os.Getenv("PATH")
+	require.NoError(t, os.Setenv("PATH", dir+":"+oldPath))
+	t.Cleanup(func() {
+		require.NoError(t, os.Setenv("PATH", oldPath))
+	})
+
+	return logPath
+}
+
 func setupTest(t *testing.T) {
+	t.Helper()
 	// By default, report all pools we use as replicated; if there are EC
 	// tests, they can override this implementation.
 	osdPoolDetailout := `
@@ -961,10 +1543,13 @@ func setupTest(t *testing.T) {
 }
 
 func teardownTest(t *testing.T) {
+	t.Helper()
 	savedOsdDumpOut = nil
 	savedOsdPoolsDetails = nil
 	savedParsedOsdTree = nil
 	savedPgDumpPgsBrief = nil
+	savedPgUpmapItemMap = nil
+	savedPgUpmapItemMapSource = nil
 
 	runOsdDump = nil
 	runOsdPoolLs = nil

--- a/mappingstate.go
+++ b/mappingstate.go
@@ -17,7 +17,6 @@ package main
 import (
 	"fmt"
 	"slices"
-	"sort"
 	"strings"
 	"sync"
 
@@ -54,7 +53,7 @@ func updateChangeState(wantedState changeStateType) changeStateType {
 func mustGetCurrentMappingState() *mappingState {
 	osdDumpOut := osdDump()
 	items := osdDumpOut.PgUpmapItems
-	sort.Slice(items, func(i, j int) bool { return items[i].PgID < items[j].PgID })
+	slices.SortFunc(items, func(a, b *pgUpmapItem) int { return strings.Compare(a.PgID, b.PgID) })
 	sanitizeStaleUpmaps(items)
 	return &mappingState{
 		pgUpmapItems: osdDumpOut.PgUpmapItems,
@@ -63,10 +62,25 @@ func mustGetCurrentMappingState() *mappingState {
 }
 
 func sanitizeStaleUpmaps(puis []*pgUpmapItem) {
-	pgBriefs := pgBriefMap()
+	if len(puis) == 0 {
+		return
+	}
 
-	hasOSD := func(osdids []int, osdid int) bool {
-		return slices.Contains(osdids, osdid)
+	// Build a set of only the PGIDs that have upmap items. In a large cluster
+	// there can be tens of thousands of PGs, but only a small fraction will
+	// have upmap entries. Building an index of every PG would over-allocate;
+	// instead we iterate pgDumpPgsBrief() once and keep only the entries we
+	// actually need, keeping the map proportional to the upmap item count.
+	targetPGIDs := make(map[string]struct{}, len(puis))
+	for _, pui := range puis {
+		targetPGIDs[pui.PgID] = struct{}{}
+	}
+
+	pgBriefs := make(map[string]*pgBriefItem, len(targetPGIDs))
+	for _, pgb := range pgDumpPgsBrief() {
+		if _, ok := targetPGIDs[pgb.PgID]; ok {
+			pgBriefs[pgb.PgID] = pgb
+		}
 	}
 
 	for _, pui := range puis {
@@ -75,9 +89,11 @@ func sanitizeStaleUpmaps(puis []*pgUpmapItem) {
 			continue
 		}
 
-		finalMappings := []mapping{}
+		finalMappings := make([]mapping, 0, len(pui.Mappings))
 		for _, m := range pui.Mappings {
-			if hasOSD(pgBrief.Up, m.From) || !hasOSD(pgBrief.Up, m.To) {
+			fromInUp := slices.Contains(pgBrief.Up, m.From)
+			toInUp := slices.Contains(pgBrief.Up, m.To)
+			if fromInUp || !toInUp {
 				// This mapping has no effect on the PG and is
 				// thus stale, but Ceph hasn't cleaned it up.
 				// It will get in the way of our own decision
@@ -116,7 +132,7 @@ func (m *mappingState) tryRemap(pgid string, from, to int) error {
 			// simply remove it.
 			pui.Mappings[i].dirty = true
 			pui.removedMappings = append(pui.removedMappings, pui.Mappings[i])
-			pui.Mappings = append(pui.Mappings[0:i], pui.Mappings[i+1:]...)
+			pui.Mappings = slices.Delete(pui.Mappings, i, i+1)
 			m.bs.accountForRemap(pgid, from, to)
 			return nil
 		}
@@ -148,8 +164,10 @@ func (m *mappingState) mustRemap(pgid string, from, to int) {
 
 func (m *mappingState) findOrMakeUpmapItem(pgid string) *pgUpmapItem {
 	puis := m.pgUpmapItems
-	i := sort.Search(len(puis), func(i int) bool { return m.pgUpmapItems[i].PgID >= pgid })
-	if i < len(puis) && puis[i].PgID == pgid {
+	i, found := slices.BinarySearchFunc(puis, pgid, func(pui *pgUpmapItem, s string) int {
+		return strings.Compare(pui.PgID, s)
+	})
+	if found {
 		return puis[i]
 	}
 
@@ -157,10 +175,7 @@ func (m *mappingState) findOrMakeUpmapItem(pgid string) *pgUpmapItem {
 	pui := &pgUpmapItem{
 		PgID: pgid,
 	}
-	puis = append(puis, &pgUpmapItem{})
-	copy(puis[i+1:], puis[i:])
-	puis[i] = pui
-	m.pgUpmapItems = puis
+	m.pgUpmapItems = slices.Insert(puis, i, pui)
 
 	return pui
 }
@@ -226,7 +241,7 @@ type pgMapping struct {
 }
 
 func (m *mappingState) getMappings(filter mappingFilter) []pgMapping {
-	mappings := []pgMapping{}
+	mappings := make([]pgMapping, 0, len(m.pgUpmapItems))
 
 	m.iterateMappings(func(pgid string, mp mapping) {
 		mappings = append(mappings, pgMapping{
@@ -244,7 +259,7 @@ func (m *mappingState) dirtyUpmapItems() []*pgUpmapItem {
 	m.l.Lock()
 	defer m.l.Unlock()
 
-	items := []*pgUpmapItem{}
+	items := make([]*pgUpmapItem, 0, len(m.pgUpmapItems))
 
 	for _, pui := range m.pgUpmapItems {
 		if pui.dirty {
@@ -276,8 +291,9 @@ func (m *mappingState) apply() {
 }
 
 func (m *mappingState) String() string {
-	strs := []string{}
-	for _, pui := range m.dirtyUpmapItems() {
+	dirty := m.dirtyUpmapItems()
+	strs := make([]string, 0, len(dirty)+1)
+	for _, pui := range dirty {
 		strs = append(strs, pui.String())
 	}
 	if len(strs) > 0 {

--- a/mappingstate_test.go
+++ b/mappingstate_test.go
@@ -22,7 +22,7 @@ import (
 
 func TestGetMappings(t *testing.T) {
 	setupTest(t)
-	defer teardownTest(t)
+	t.Cleanup(func() { teardownTest(t) })
 	pgDumpOut := `
 [
  { "pgid": "1.1", "up": [ 1, 2, 4 ], "acting": [ 1, 2, 3 ], "state": "backfill_wait" },
@@ -99,4 +99,121 @@ func TestGetMappings(t *testing.T) {
 			require.ElementsMatch(t, tt.expected, got)
 		})
 	}
+}
+
+func TestTryRemapRemovesExactOppositeMapping(t *testing.T) {
+	setupTest(t)
+	t.Cleanup(func() { teardownTest(t) })
+
+	runOsdDump = func() (string, error) {
+		return `
+{
+  "osds": [],
+  "pg_upmap_items": [
+    { "pgid": "1.1", "mappings": [ { "from": 5, "to": 6 } ] }
+  ]
+}
+`, nil
+	}
+	runPgDumpPgsBrief = func() (string, error) {
+		return `
+[
+  { "pgid": "1.1", "up": [ 6 ], "acting": [ 5 ], "state": "active+remapped" }
+]
+`, nil
+	}
+	runOsdPoolLs = func() (string, error) {
+		return `[{"pool_id":1,"pool_name":"replicated","erasure_code_profile":""}]`, nil
+	}
+
+	M = mustGetCurrentMappingState()
+	err := M.tryRemap("1.1", 6, 5)
+	require.NoError(t, err)
+
+	require.Empty(t, M.getMappings(withPgid("1.1")))
+	dirty := M.dirtyUpmapItems()
+	require.Len(t, dirty, 1)
+	require.Len(t, dirty[0].Mappings, 0)
+	require.Len(t, dirty[0].removedMappings, 1)
+	require.Equal(t, 5, dirty[0].removedMappings[0].From)
+	require.Equal(t, 6, dirty[0].removedMappings[0].To)
+}
+
+func TestSanitizeStaleUpmapsFiltersByUpSetAndLeavesUnknownPGUntouched(t *testing.T) {
+	setupTest(t)
+	t.Cleanup(func() { teardownTest(t) })
+
+	runOsdDump = func() (string, error) {
+		return `
+{
+  "osds": [],
+  "pg_upmap_items": [
+    {
+      "pgid": "1.1",
+      "mappings": [
+        { "from": 1, "to": 2 },
+        { "from": 4, "to": 5 },
+        { "from": 4, "to": 2 },
+        { "from": 2, "to": 3 }
+      ]
+    },
+    {
+      "pgid": "1.2",
+      "mappings": [
+        { "from": 8, "to": 9 }
+      ]
+    }
+  ]
+}
+`, nil
+	}
+
+	runPgDumpPgsBrief = func() (string, error) {
+		return `
+[
+  { "pgid": "1.1", "up": [ 1, 2, 3 ], "acting": [ 1, 2, 3 ], "state": "active+clean" }
+]
+`, nil
+	}
+
+	M = mustGetCurrentMappingState()
+
+	var p11, p12 *pgUpmapItem
+	for _, pui := range M.pgUpmapItems {
+		switch pui.PgID {
+		case "1.1":
+			p11 = pui
+		case "1.2":
+			p12 = pui
+		}
+	}
+
+	require.NotNil(t, p11)
+	require.NotNil(t, p12)
+
+	// Only mapping 4->2 should remain for 1.1.
+	require.Equal(t, []mapping{{From: 4, To: 2}}, p11.Mappings)
+	require.ElementsMatch(t, []mapping{
+		{From: 1, To: 2, dirty: true},
+		{From: 4, To: 5, dirty: true},
+		{From: 2, To: 3, dirty: true},
+	}, p11.staleMappings)
+
+	// PG 1.2 has no pg_brief entry; it should remain untouched.
+	require.Equal(t, []mapping{{From: 8, To: 9}}, p12.Mappings)
+	require.Empty(t, p12.staleMappings)
+}
+
+func TestMappingStateStringIncludesOnlyDirtyItemsAndLegend(t *testing.T) {
+	m := &mappingState{
+		pgUpmapItems: []*pgUpmapItem{
+			{PgID: "1.1", Mappings: []mapping{{From: 1, To: 2}}, dirty: true},
+			{PgID: "1.2", Mappings: []mapping{{From: 3, To: 4}}, dirty: false},
+		},
+	}
+
+	got := m.String()
+	require.Contains(t, got, "pg 1.1")
+	require.Contains(t, got, "Legend:")
+	require.NotContains(t, got, "pg 1.2")
 }


### PR DESCRIPTION
Add benchmarking tests and README documentation.  Numerous significant improvements to code based on iterative runs of the benchmark, refactoring code and adding additional benchmarks, or tests.

Impact:
# Benchmark Comparison Results

| Benchmark | Test | Original ns/op | New ns/op | Δ ns/op | Original B/op | New B/op | Δ B/op | Original allocs/op | New allocs/op | Δ allocs/op |
|-----------|------|----------------|-----------|---------|---------------|----------|--------|--------------------|---------------|-------------|
| BenchmarkMustGetCurrentMappingState | small-8 | 11,434,218 | 9,528,867 | -16.7% | 3,138,058 | 1,867,982 | -40.5% | 52,195 | 37,119 | -28.8% |
| BenchmarkMustGetCurrentMappingState | medium-8 | 30,417,606 | 26,208,713 | -13.8% | 12,461,741 | 7,479,941 | -39.9% | 208,433 | 148,203 | -28.9% |
| BenchmarkMustGetCurrentMappingState | large-8 | 120,747,148 | 90,087,658 | -25.4% | 50,486,614 | 30,683,584 | -39.2% | 833,357 | 592,516 | -28.9% |
| BenchmarkMustGetCurrentMappingStateLegacyJSON | small-8 |  | 9,690,610 |  |  | 1,867,926 |  |  | 37,117 |  |
| BenchmarkMustGetCurrentMappingStateLegacyJSON | medium-8 |  | 26,129,703 |  |  | 7,479,904 |  |  | 148,201 |  |
| BenchmarkMustGetCurrentMappingStateLegacyJSON | large-8 |  | 90,300,395 |  |  | 30,683,529 |  |  | 592,514 |  |
| BenchmarkCalcPgMappingsToUndoBackfill | small-8 | 16,413,102 | 13,948,699 | -15.0% | 3,972,010 | 2,073,725 | -47.8% | 65,910 | 39,882 | -39.5% |
| BenchmarkCalcPgMappingsToUndoBackfill | medium-8 | 47,989,834 | 34,761,084 | -27.5% | 15,257,223 | 8,302,134 | -45.6% | 263,117 | 159,162 | -39.5% |
| BenchmarkCalcPgMappingsToUndoBackfill | large-8 | 172,888,991 | 113,219,697 | -34.5% | 61,118,536 | 34,078,135 | -44.2% | 1,051,888 | 636,248 | -39.5% |
| BenchmarkCalcPgMappingsToDrainOsd | small-8 | 71,042,975 | 43,137,217 | -39.3% | 16,658,772 | 13,914,102 | -16.5% | 417,613 | 39,001 | -90.7% |
| BenchmarkCalcPgMappingsToDrainOsd | medium-8 | 79,123,788 | 56,851,963 | -28.1% | 26,106,239 | 19,740,991 | -24.4% | 575,945 | 152,210 | -73.6% |
| BenchmarkCalcPgMappingsToDrainOsd | large-8 | 191,583,932 | 153,921,553 | -19.7% | 65,207,584 | 43,825,932 | -32.8% | 1,209,341 | 605,007 | -49.9% |
| BenchmarkCalcPgMappingsToUndoUpmaps | small-8 | 200,001,405 | 10,639,069 | -94.7% | 117,088,990 | 1,990,615 | -98.3% | 111,408 | 38,559 | -65.4% |
| BenchmarkCalcPgMappingsToUndoUpmaps | medium-8 | 2,350,508,930 | 26,820,746 | -98.9% | 1,813,717,012 | 7,958,489 | -99.6% | 560,061 | 153,851 | -72.5% |
| BenchmarkCalcPgMappingsToUndoUpmaps | large-8 | 24,504,742,986 | 95,959,828 | -99.6% | 28,742,183,301 | 32,625,441 | -99.9% | 3,945,517 | 615,004 | -84.4% |
| BenchmarkCalcPgMappingsToBalanceOsds | small-8 | 13,269,599 | 9,268,311 | -30.1% | 3,170,515 | 1,902,283 | -40.0% | 52,414 | 37,338 | -28.7% |
| BenchmarkCalcPgMappingsToBalanceOsds | medium-8 | 31,954,823 | 26,079,697 | -18.4% | 12,502,672 | 7,514,257 | -39.9% | 208,653 | 148,422 | -28.8% |
| BenchmarkCalcPgMappingsToBalanceOsds | large-8 | 116,185,334 | 91,074,987 | -21.6% | 50,521,320 | 30,717,746 | -39.2% | 833,576 | 592,735 | -28.9% |
| BenchmarkImportMappingsLoop | small-8 | 203,225,079 | 10,602,477 | -94.8% | 117,297,093 | 1,992,297 | -98.3% | 112,989 | 38,639 | -65.8% |
| BenchmarkImportMappingsLoop | medium-8 | 2,314,901,014 | 27,110,779 | -98.8% | 1,813,358,903 | 7,967,329 | -99.6% | 566,646 | 154,231 | -72.8% |
| BenchmarkImportMappingsLoop | large-8 | 24,220,767,435 | 98,135,411 | -99.6% | 28,741,009,808 | 32,663,195 | -99.9% | 3,972,295 | 616,584 | -84.5% |
| BenchmarkExportMappings | small-8 | 203,832,152 | 10,275,006 | -95.0% | 117,198,357 | 1,991,624 | -98.3% | 111,314 | 38,572 | -65.3% |
| BenchmarkExportMappings | medium-8 | 2,279,265,827 | 27,300,936 | -98.8% | 1,813,272,375 | 7,959,478 | -99.6% | 559,895 | 153,864 | -72.5% |
| BenchmarkExportMappings | large-8 | 24,611,868,229 | 95,992,547 | -99.6% | 28,742,835,394 | 32,626,524 | -99.9% | 3,945,497 | 615,017 | -84.4% |
| BenchmarkRemapSingle | small-8 | 13,245,572 | 10,297,120 | -22.2% | 3,151,222 | 1,868,113 | -40.7% | 52,208 | 37,122 | -28.9% |
| BenchmarkRemapSingle | medium-8 | 31,505,698 | 26,007,101 | -17.5% | 12,474,771 | 7,480,049 | -40.0% | 208,446 | 148,206 | -28.9% |
| BenchmarkRemapSingle | large-8 | 115,908,597 | 90,438,220 | -21.9% | 50,508,131 | 30,683,649 | -39.2% | 833,371 | 592,519 | -28.9% |
| BenchmarkGenerateCrushChangeMappings | small-8 | 2,580,895 | 2,927,772 | +13.4% | 2,073,704 | 2,073,647 | -0.0% | 16,438 | 16,436 | -0.0% |
| BenchmarkGenerateCrushChangeMappings | medium-8 | 10,202,671 | 10,862,061 | +6.5% | 8,302,299 | 8,302,252 | -0.0% | 65,688 | 65,686 | -0.0% |
| BenchmarkGenerateCrushChangeMappings | large-8 | 47,727,619 | 47,607,074 | -0.3% | 33,206,249 | 33,206,194 | -0.0% | 262,682 | 262,680 | -0.0% |
