### PR TITLE
pgremapper: Drain opportunistic balancing

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -34,13 +34,17 @@ jobs:
       with:
         go-version-file: go.mod
 
-    - name: Build
-      run: go build -v ./...
-
-    - name: Static code checks
+    - name: Set up golangci-lint
       uses: golangci/golangci-lint-action@v9
       with:
         version: v2.11.4
+        install-only: true
+
+    - name: Static code checks (gofmt)
+      run: golangci-lint fmt --diff --enable gofmt
+
+    - name: Build
+      run: go build -v ./...
 
     - name: Test
       run: go test -v ./...

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -34,17 +34,13 @@ jobs:
       with:
         go-version-file: go.mod
 
-    - name: Set up golangci-lint
+    - name: Build
+      run: go build -v ./...
+
+    - name: Static code checks
       uses: golangci/golangci-lint-action@v9
       with:
         version: v2.11.4
-        install-only: true
-
-    - name: Static code checks (gofmt)
-      run: golangci-lint fmt --diff --enable gofmt
-
-    - name: Build
-      run: go build -v ./...
 
     - name: Test
       run: go test -v ./...

--- a/README.md
+++ b/README.md
@@ -281,7 +281,8 @@ $ ./pgremapper cancel-backfill --pgs-including bucket:data10
 
 ### drain
 
-Remap PGs off of the given source OSD spec(s), up to the given maximum number of scheduled backfills. No attempt is made to balance the fullness of the target OSDs; rather, the least busy target OSDs and PGs will be selected.
+Remap PGs off of the given source OSD spec(s), up to the given maximum number of scheduled backfills. The remapping logic uses a capped reservation penalty in its scoring function: it strongly prefers target OSDs with fewer remote reservations, but once the cap is reached, it distributes PGs to balance PG counts as evenly as possible across all targets. This opportunistic balancing improves usage balance and reduces skew, while ensuring no OSD is permanently excluded due to high reservation counts.
+
 If a source OSD is included among target OSDs, it will be removed from the targets.
 
 ```

--- a/README.md
+++ b/README.md
@@ -51,6 +51,99 @@ docker run --rm -v $(pwd):/pgremapper -w /pgremapper golang:1.21.4 go build -o p
 
 You can also download one of the pre-built binaries from the [releases page](https://github.com/digitalocean/pgremapper/releases).
 
+## Performance Profiling
+
+This repository includes benchmark scaffolding in `benchmark_test.go` so you can profile parsing and remap decision paths without a live Ceph cluster.
+
+### 1) Run benchmarks
+
+Run all benchmarks using Go's default benchtime:
+
+```
+go test -run '^$' -bench=. -benchmem ./...
+```
+
+Run all benchmarks with a fixed time budget per benchmark, saving results to a file:
+
+```
+go test -run '^$' -bench=. -benchtime=60s -benchmem ./... | tee bench-results.txt
+```
+
+Run a specific benchmark family only:
+
+```
+go test -run '^$' -bench='^BenchmarkCalc' -benchtime=60s -benchmem ./...
+```
+
+`-bench=.` matches every benchmark function. `-benchmem` adds `B/op` and `allocs/op` columns.
+
+Benchmark fixture profiles used in `benchmark_test.go`:
+
+* `small`: `pgCount=4096`, `osdCount=128`, and for upmap-heavy cases `upmapCount=300`.
+* `medium`: `pgCount=16384`, `osdCount=512`, and for upmap-heavy cases `upmapCount=1200`.
+* `large`: `pgCount=65536`, `osdCount=2048`, and for upmap-heavy cases `upmapCount=4800`.
+
+Notes:
+
+* All benchmark families include `small`, `medium`, and `large` sub-benchmarks.
+* `-benchtime=60s` applies per benchmark/sub-benchmark that is selected (for example, `.../small` or `.../medium`).
+
+### 2) Capture CPU and heap profiles
+
+```
+go test -run '^$' -bench BenchmarkMustGetCurrentMappingState/large -benchmem \
+  -cpuprofile cpu.out -memprofile mem.out ./...
+```
+
+You can swap the benchmark selector for any benchmark/sub-benchmark, for example:
+
+```
+go test -run '^$' -bench BenchmarkCalcPgMappingsToUndoBackfill/medium -benchmem \
+  -cpuprofile cpu.out -memprofile mem.out ./...
+```
+
+### 3) Inspect profiles with pprof
+
+CPU profile:
+
+```
+go tool pprof -top cpu.out
+```
+
+Heap allocation profile:
+
+```
+go tool pprof -top -alloc_space mem.out
+```
+
+To open an interactive web UI:
+
+```
+go tool pprof -http=:8080 cpu.out
+```
+
+Then open `http://localhost:8080` in a browser.
+
+### 4) Useful pprof commands inside interactive mode
+
+If you run `go tool pprof cpu.out`, these commands are useful:
+
+* `top` - hottest functions by self time
+* `top -cum` - hottest functions by cumulative time
+* `list <function>` - annotated source for a function
+* `web` - render the call graph (requires Graphviz installed)
+
+### 5) Repeatability tips
+
+* Run each benchmark at least 3 times and compare medians.
+* If results are noisy, increase benchmark time:
+
+```
+go test -run '^$' -bench BenchmarkMustGetCurrentMappingState/large -benchmem -benchtime=60s ./...
+```
+
+* Keep your machine load low and avoid running other heavy workloads while profiling.
+
 ## Usage
 
 `pgremapper` makes no changes by default and has some global options:

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Notes:
 * Benchmark setup is included in timed sections, so wall-clock runtime more closely tracks the benchtime target.
 * Use `-benchtime=1x` when you want exactly one iteration for quick smoke checks.
 
-### 2) Capture CPU and heap profiles
+### 2) Capture CPU, heap, mutex, and block profiles
 
 ```
 go test -run '^$' -bench BenchmarkMustGetCurrentMappingState/large -benchmem \
@@ -103,6 +103,21 @@ You can swap the benchmark selector for any benchmark/sub-benchmark, for example
 go test -run '^$' -bench BenchmarkCalcPgMappingsToUndoBackfill/medium -benchmem \
   -cpuprofile cpu.out -memprofile mem.out ./...
 ```
+
+To include mutex and block contention profiles in the same run:
+
+```
+go test -run '^$' -bench BenchmarkCalcPgMappingsToUndoBackfill/medium -benchmem \
+  -cpuprofile cpu.out -memprofile mem.out \
+  -mutexprofile mutex.out -blockprofile block.out ./...
+```
+
+Notes for contention profiles:
+
+* `-mutexprofile` captures time spent waiting on contended mutexes.
+* `-blockprofile` captures goroutine blocking events (channel ops, selects, mutex waits, etc.).
+* In benchmark-wide runs, block profiles often contain significant `testing` harness channel waits; prefer targeted benchmark selectors when investigating an individual code path.
+* If needed, you can tune sampling rates in code via `runtime.SetMutexProfileFraction` and `runtime.SetBlockProfileRate`, but defaults are often sufficient for comparative benchmark runs.
 
 ### 3) Inspect profiles with pprof
 
@@ -118,6 +133,25 @@ Heap allocation profile:
 go tool pprof -top -alloc_space mem.out
 ```
 
+Mutex contention profile (delay view):
+
+```
+go tool pprof -top mutex.out
+```
+
+Block profile (delay view):
+
+```
+go tool pprof -top block.out
+```
+
+Contention/event count views:
+
+```
+go tool pprof -top -sample_index=contentions mutex.out
+go tool pprof -top -sample_index=contentions block.out
+```
+
 To open an interactive web UI:
 
 ```
@@ -128,7 +162,7 @@ Then open `http://localhost:8080` in a browser.
 
 ### 4) Useful pprof commands inside interactive mode
 
-If you run `go tool pprof cpu.out`, these commands are useful:
+If you run `go tool pprof <profile.out>`, these commands are useful:
 
 * `top` - hottest functions by self time
 * `top -cum` - hottest functions by cumulative time

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ go install github.com/digitalocean/pgremapper@latest
 
 Otherwise, clone this repository and use a golang Docker container to build:
 ```
-docker run --rm -v $(pwd):/pgremapper -w /pgremapper golang:1.21.4 go build -o pgremapper .
+docker run --rm -v $(pwd):/pgremapper -w /pgremapper golang:1.26.2 go build -o pgremapper .
 ```
 
 You can also download one of the pre-built binaries from the [releases page](https://github.com/digitalocean/pgremapper/releases).

--- a/README.md
+++ b/README.md
@@ -87,6 +87,8 @@ Notes:
 
 * All benchmark families include `small`, `medium`, and `large` sub-benchmarks.
 * `-benchtime=60s` applies per benchmark/sub-benchmark that is selected (for example, `.../small` or `.../medium`).
+* Benchmark setup is included in timed sections, so wall-clock runtime more closely tracks the benchtime target.
+* Use `-benchtime=1x` when you want exactly one iteration for quick smoke checks.
 
 ### 2) Capture CPU and heap profiles
 

--- a/backfillstate.go
+++ b/backfillstate.go
@@ -186,8 +186,9 @@ func (bs *backfillState) getMaxBackfillReservations(osd int) int {
 }
 
 func computeBackfillSrcsTgts(pgb *pgBriefItem) ([]int, []int) {
-	srcs := []int{}
-	tgts := []int{}
+	// Pre-allocate based on up/acting length; backfills can't exceed this.
+	srcs := make([]int, 0, len(pgb.Acting))
+	tgts := make([]int, 0, len(pgb.Up))
 	up := pgb.Up
 	acting := pgb.Acting
 

--- a/backfillstate.go
+++ b/backfillstate.go
@@ -166,9 +166,12 @@ func (bs *backfillState) hasRoomForRemap(pgid string, from, to int) bool {
 		hasRoom = false
 	}
 
-	_, tgts := computeBackfillSrcsTgts(pgb)
-	for _, osd := range tgts {
-		if bs.osd(osd).remoteReservations > bs.getMaxBackfillReservations(osd) {
+	// Avoid transient target-slice allocation in this hot check path.
+	for i := range pgb.Acting {
+		if pgb.Up[i] == pgb.Acting[i] {
+			continue
+		}
+		if bs.osd(pgb.Up[i]).remoteReservations > bs.getMaxBackfillReservations(pgb.Up[i]) {
 			hasRoom = false
 		}
 	}

--- a/backfillstate_test.go
+++ b/backfillstate_test.go
@@ -103,3 +103,87 @@ func TestBackfillState(t *testing.T) {
 	require.Equal(t, 1, bs.osd(77).remoteReservations)
 	require.Equal(t, 1, bs.osd(77).backfillsFrom)
 }
+
+func TestHasRoomForRemapDoesNotMutateState(t *testing.T) {
+	setupTest(t)
+	t.Cleanup(func() { teardownTest(t) })
+
+	pgDumpOut := `
+[
+ { "pgid": "1.01", "up": [ 77, 1, 2 ], "acting": [ 77, 1, 2 ] },
+ { "pgid": "1.02", "up": [ 77, 3, 4 ], "acting": [ 77, 3, 5 ] },
+ { "pgid": "1.03", "up": [ 77, 5, 6 ], "acting": [ 3, 5, 7 ] }
+]
+`
+	runOsdDump = func() (string, error) { return "{}", nil }
+	runPgDumpPgsBrief = func() (string, error) { return pgDumpOut, nil }
+
+	bs := mustGetCurrentBackfillState()
+
+	type osdCounters struct {
+		local, remote, from, max int
+	}
+	snapshotOSDs := func() map[int]osdCounters {
+		out := make(map[int]osdCounters, len(bs.osds))
+		for osd, s := range bs.osds {
+			out[osd] = osdCounters{
+				local:  s.localReservations,
+				remote: s.remoteReservations,
+				from:   s.backfillsFrom,
+				max:    s.maxBackfillReservations,
+			}
+		}
+		return out
+	}
+	snapshotUp := func() map[string][]int {
+		out := make(map[string][]int, len(bs.pgbs))
+		for id, pgb := range bs.pgbs {
+			dup := make([]int, len(pgb.Up))
+			copy(dup, pgb.Up)
+			out[id] = dup
+		}
+		return out
+	}
+
+	beforeOSDs := snapshotOSDs()
+	beforeUp := snapshotUp()
+
+	// Valid remap probe path; hasRoomForRemap applies and reverts internally.
+	_ = bs.hasRoomForRemap("1.02", 4, 5)
+
+	require.Equal(t, beforeOSDs, snapshotOSDs())
+	require.Equal(t, beforeUp, snapshotUp())
+}
+
+func TestHasRoomForRemapRespectsSourceAndTargetLimits(t *testing.T) {
+	setupTest(t)
+	t.Cleanup(func() { teardownTest(t) })
+
+	pgDumpOut := `
+[
+ { "pgid": "1.01", "up": [ 77, 1, 2 ], "acting": [ 77, 1, 2 ] },
+ { "pgid": "1.02", "up": [ 77, 3, 4 ], "acting": [ 77, 3, 5 ] },
+ { "pgid": "1.03", "up": [ 77, 5, 6 ], "acting": [ 3, 5, 7 ] }
+]
+`
+	runOsdDump = func() (string, error) { return "{}", nil }
+	runPgDumpPgsBrief = func() (string, error) { return pgDumpOut, nil }
+
+	t.Run("source backfill limit", func(t *testing.T) {
+		bs := mustGetCurrentBackfillState()
+		// from=4 currently has no source backfills; cap at 0 blocks it.
+		bs.maxBackfillsFrom = 0
+		require.False(t, bs.hasRoomForRemap("1.02", 4, 5))
+	})
+
+	t.Run("target reservation limit", func(t *testing.T) {
+		bs := mustGetCurrentBackfillState()
+		// Make source limit permissive so target-side check is exercised.
+		bs.maxBackfillsFrom = 1000
+
+		// 1.01 is currently clean. Remapping 1->6 introduces backfill with target=6.
+		// Cap target OSD 6 at zero reservations so this must be rejected.
+		bs.osd(6).maxBackfillReservations = 0
+		require.False(t, bs.hasRoomForRemap("1.01", 1, 6))
+	})
+}

--- a/backfillstate_test.go
+++ b/backfillstate_test.go
@@ -22,7 +22,7 @@ import (
 
 func TestBackfillState(t *testing.T) {
 	setupTest(t)
-	defer teardownTest(t)
+	t.Cleanup(func() { teardownTest(t) })
 	pgDumpOut := `
 [
  { "pgid": "1.01", "up": [ 77, 1, 2 ], "acting": [ 77, 1, 2 ] },

--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -1,0 +1,543 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+type benchmarkFixture struct {
+	pgDump  string
+	osdDump string
+	osdTree string
+	poolLs  string
+}
+
+func resetBenchmarkGlobals() {
+	savedOsdDumpOut = nil
+	savedOsdPoolsDetails = nil
+	savedParsedOsdTree = nil
+	savedPgDumpPgsBrief = nil
+
+	M = nil
+}
+
+func installFixture(f benchmarkFixture) {
+	runOsdDump = func() (string, error) { return f.osdDump, nil }
+	runPgDumpPgsBrief = func() (string, error) { return f.pgDump, nil }
+	runOsdTree = func() (string, error) { return f.osdTree, nil }
+	runOsdPoolLs = func() (string, error) { return f.poolLs, nil }
+	runCrushCmp = func(_ string) (string, error) {
+		panic("runCrushCmp should not be called in this benchmark")
+	}
+	runPgQuery = func(_ string) (string, error) {
+		panic("runPgQuery should not be called in benchmarks")
+	}
+}
+
+func makePoolJSON() string {
+	return `[
+ { "pool_id": 1, "pool_name": "replicated", "erasure_code_profile": "" }
+]`
+}
+
+func makeOsdDumpJSON(osdCount int) string {
+	var b strings.Builder
+	b.Grow(osdCount * 40)
+	b.WriteString("{\n  \"osds\": [\n")
+	for i := 0; i < osdCount; i++ {
+		if i > 0 {
+			b.WriteString(",\n")
+		}
+		fmt.Fprintf(&b, "    { \"osd\": %d, \"in\": 1, \"up\": 1 }", i)
+	}
+	b.WriteString("\n  ],\n  \"pg_upmap_items\": []\n}\n")
+	return b.String()
+}
+
+func makeOsdDumpJSONWithUpmaps(osdCount int, upmapCount int) string {
+	if upmapCount < 0 {
+		upmapCount = 0
+	}
+
+	var b strings.Builder
+	b.Grow(osdCount*40 + upmapCount*80)
+	b.WriteString("{\n  \"osds\": [\n")
+	for i := 0; i < osdCount; i++ {
+		if i > 0 {
+			b.WriteString(",\n")
+		}
+		fmt.Fprintf(&b, "    { \"osd\": %d, \"in\": 1, \"up\": 1 }", i)
+	}
+
+	b.WriteString("\n  ],\n  \"pg_upmap_items\": [\n")
+	for i := 0; i < upmapCount; i++ {
+		if i > 0 {
+			b.WriteString(",\n")
+		}
+		from := (i + 13) % osdCount
+		to := (from + 5) % osdCount
+		if to == from {
+			to = (to + 1) % osdCount
+		}
+		fmt.Fprintf(
+			&b,
+			"    { \"pgid\": \"1.%x\", \"mappings\": [ { \"from\": %d, \"to\": %d } ] }",
+			i,
+			from,
+			to,
+		)
+	}
+	b.WriteString("\n  ]\n}\n")
+	return b.String()
+}
+
+func makeOsdTreeJSON(osdCount int, osdsPerHost int) string {
+	if osdsPerHost <= 0 {
+		osdsPerHost = 8
+	}
+	hostCount := (osdCount + osdsPerHost - 1) / osdsPerHost
+
+	var b strings.Builder
+	b.Grow(osdCount * 50)
+	b.WriteString("{\n  \"nodes\": [\n")
+	b.WriteString("    { \"id\": -1, \"name\": \"default\", \"type\": \"root\", \"children\": [")
+	for h := 0; h < hostCount; h++ {
+		if h > 0 {
+			b.WriteString(",")
+		}
+		fmt.Fprintf(&b, "%d", -1000-h)
+	}
+	b.WriteString("] },\n")
+
+	for h := 0; h < hostCount; h++ {
+		if h > 0 {
+			b.WriteString(",\n")
+		}
+		start := h * osdsPerHost
+		end := start + osdsPerHost
+		if end > osdCount {
+			end = osdCount
+		}
+		fmt.Fprintf(&b, "    { \"id\": %d, \"name\": \"host%d\", \"type\": \"host\", \"children\": [", -1000-h, h)
+		for i := start; i < end; i++ {
+			if i > start {
+				b.WriteString(",")
+			}
+			fmt.Fprintf(&b, "%d", i)
+		}
+		b.WriteString("] }")
+	}
+
+	for i := 0; i < osdCount; i++ {
+		b.WriteString(",\n")
+		fmt.Fprintf(&b, "    { \"id\": %d, \"name\": \"osd.%d\", \"type\": \"osd\", \"reweight\": 1.0 }", i, i)
+	}
+	b.WriteString("\n  ]\n}\n")
+	return b.String()
+}
+
+func makePgDumpJSON(pgCount int, osdCount int) string {
+	var b strings.Builder
+	b.Grow(pgCount * 130)
+	b.WriteString("[\n")
+	for i := 0; i < pgCount; i++ {
+		if i > 0 {
+			b.WriteString(",\n")
+		}
+
+		a0 := i % osdCount
+		a1 := (i + 7) % osdCount
+		a2 := (i + 13) % osdCount
+
+		u0 := a0
+		u1 := a1
+		u2 := a2
+		state := "active+clean"
+		if i%3 == 0 {
+			u2 = (a2 + 5) % osdCount
+			if u2 == a0 || u2 == a1 {
+				u2 = (u2 + 11) % osdCount
+			}
+			state = "active+remapped+backfill_wait"
+		}
+
+		fmt.Fprintf(
+			&b,
+			" { \"pgid\": \"1.%x\", \"up\": [ %d, %d, %d ], \"acting\": [ %d, %d, %d ], \"state\": \"%s\" }",
+			i,
+			u0, u1, u2,
+			a0, a1, a2,
+			state,
+		)
+	}
+	b.WriteString("\n]\n")
+	return b.String()
+}
+
+func makeBenchmarkFixture(pgCount int, osdCount int) benchmarkFixture {
+	return benchmarkFixture{
+		pgDump:  makePgDumpJSON(pgCount, osdCount),
+		osdDump: makeOsdDumpJSON(osdCount),
+		osdTree: makeOsdTreeJSON(osdCount, 8),
+		poolLs:  makePoolJSON(),
+	}
+}
+
+func makeBenchmarkFixtureWithUpmaps(pgCount int, osdCount int, upmapCount int) benchmarkFixture {
+	if upmapCount > pgCount {
+		upmapCount = pgCount
+	}
+
+	return benchmarkFixture{
+		pgDump:  makePgDumpJSON(pgCount, osdCount),
+		osdDump: makeOsdDumpJSONWithUpmaps(osdCount, upmapCount),
+		osdTree: makeOsdTreeJSON(osdCount, 8),
+		poolLs:  makePoolJSON(),
+	}
+}
+
+func makeSyntheticImportMappings(count int, osdCount int) []pgMapping {
+	out := make([]pgMapping, 0, count)
+	for i := 0; i < count; i++ {
+		from := (i + 13) % osdCount
+		to := (from + 17) % osdCount
+		if to == from {
+			to = (to + 1) % osdCount
+		}
+		out = append(out, pgMapping{
+			PgID: fmt.Sprintf("1.%x", i),
+			Mapping: mapping{
+				From: from,
+				To:   to,
+			},
+		})
+	}
+	return out
+}
+
+func makeSyntheticCrushDiffOutput(pgCount int, osdCount int) string {
+	var b strings.Builder
+	b.Grow(pgCount * 60)
+	b.WriteString("# synthetic crushdiff output\n")
+	for i := 0; i < pgCount; i++ {
+		a0 := i % osdCount
+		a1 := (i + 7) % osdCount
+		a2 := (i + 13) % osdCount
+		n2 := (a2 + 5) % osdCount
+		if n2 == a0 || n2 == a1 {
+			n2 = (n2 + 11) % osdCount
+		}
+		fmt.Fprintf(&b, "1.%x\t[%d, %d, %d] -> [%d, %d, %d]\n", i, a0, a1, a2, a0, a1, n2)
+	}
+	return b.String()
+}
+
+func BenchmarkMustGetCurrentMappingState(b *testing.B) {
+	for _, tt := range []struct {
+		name     string
+		pgCount  int
+		osdCount int
+	}{
+		{name: "small", pgCount: 4096, osdCount: 128},
+		{name: "medium", pgCount: 16384, osdCount: 512},
+		{name: "large", pgCount: 65536, osdCount: 2048},
+	} {
+		fixture := makeBenchmarkFixture(tt.pgCount, tt.osdCount)
+
+		b.Run(tt.name, func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				b.StopTimer()
+				resetBenchmarkGlobals()
+				installFixture(fixture)
+				b.StartTimer()
+
+				_ = mustGetCurrentMappingState()
+			}
+		})
+	}
+}
+
+func BenchmarkCalcPgMappingsToUndoBackfill(b *testing.B) {
+	for _, tt := range []struct {
+		name     string
+		pgCount  int
+		osdCount int
+	}{
+		{name: "small", pgCount: 4096, osdCount: 128},
+		{name: "medium", pgCount: 16384, osdCount: 512},
+		{name: "large", pgCount: 65536, osdCount: 2048},
+	} {
+		fixture := makeBenchmarkFixture(tt.pgCount, tt.osdCount)
+
+		b.Run(tt.name, func(b *testing.B) {
+			b.ReportAllocs()
+
+			excludedOsds := map[int]struct{}{}
+			includedOsds := map[int]struct{}{}
+			excludedPools := map[int]struct{}{}
+			includedPools := map[int]struct{}{}
+			pgsIncludingOsds := map[int]struct{}{}
+
+			for i := 0; i < b.N; i++ {
+				b.StopTimer()
+				resetBenchmarkGlobals()
+				installFixture(fixture)
+				M = mustGetCurrentMappingState()
+				b.StartTimer()
+
+				calcPgMappingsToUndoBackfill(
+					true,
+					false,
+					false,
+					excludedOsds,
+					includedOsds,
+					excludedPools,
+					includedPools,
+					pgsIncludingOsds,
+				)
+			}
+		})
+	}
+}
+
+func BenchmarkCalcPgMappingsToDrainOsd(b *testing.B) {
+	for _, tt := range []struct {
+		name     string
+		pgCount  int
+		osdCount int
+	}{
+		{name: "small", pgCount: 4096, osdCount: 128},
+		{name: "medium", pgCount: 16384, osdCount: 512},
+		{name: "large", pgCount: 65536, osdCount: 2048},
+	} {
+		fixture := makeBenchmarkFixture(tt.pgCount, tt.osdCount)
+
+		targets := make(map[int]struct{})
+		for i := 1; i < tt.osdCount && i < 64; i++ {
+			targets[i] = struct{}{}
+		}
+
+		b.Run(tt.name, func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				b.StopTimer()
+				resetBenchmarkGlobals()
+				installFixture(fixture)
+				M = mustGetCurrentMappingState()
+				M.bs.maxBackfillsFrom = 4096
+				b.StartTimer()
+
+				calcPgMappingsToDrainOsd("", []int{0}, targets)
+			}
+		})
+	}
+}
+
+func BenchmarkCalcPgMappingsToUndoUpmaps(b *testing.B) {
+	for _, tt := range []struct {
+		name       string
+		pgCount    int
+		osdCount   int
+		upmapCount int
+	}{
+		{name: "small", pgCount: 4096, osdCount: 128, upmapCount: 300},
+		{name: "medium", pgCount: 16384, osdCount: 512, upmapCount: 1200},
+		{name: "large", pgCount: 65536, osdCount: 2048, upmapCount: 4800},
+	} {
+		fixture := makeBenchmarkFixtureWithUpmaps(tt.pgCount, tt.osdCount, tt.upmapCount)
+
+		osds := make([]int, 0, 16)
+		for i := 0; i < 16 && i < tt.osdCount; i++ {
+			osds = append(osds, i)
+		}
+
+		b.Run(tt.name, func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				b.StopTimer()
+				resetBenchmarkGlobals()
+				installFixture(fixture)
+				M = mustGetCurrentMappingState()
+				M.bs.maxBackfillsFrom = 4096
+				b.StartTimer()
+
+				calcPgMappingsToUndoUpmaps(osds, false)
+			}
+		})
+	}
+}
+
+func BenchmarkCalcPgMappingsToBalanceOsds(b *testing.B) {
+	for _, tt := range []struct {
+		name     string
+		pgCount  int
+		osdCount int
+	}{
+		{name: "small", pgCount: 4096, osdCount: 128},
+		{name: "medium", pgCount: 16384, osdCount: 512},
+		{name: "large", pgCount: 65536, osdCount: 2048},
+	} {
+		fixture := makeBenchmarkFixture(tt.pgCount, tt.osdCount)
+
+		osds := make([]int, 0, 32)
+		for i := 0; i < 32 && i < tt.osdCount; i++ {
+			osds = append(osds, i)
+		}
+
+		b.Run(tt.name, func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				b.StopTimer()
+				resetBenchmarkGlobals()
+				installFixture(fixture)
+				M = mustGetCurrentMappingState()
+				b.StartTimer()
+
+				calcPgMappingsToBalanceOsds(osds, 64, 1)
+			}
+		})
+	}
+}
+
+func BenchmarkImportMappingsLoop(b *testing.B) {
+	for _, tt := range []struct {
+		name       string
+		pgCount    int
+		osdCount   int
+		upmapCount int
+	}{
+		{name: "small", pgCount: 4096, osdCount: 128, upmapCount: 300},
+		{name: "medium", pgCount: 16384, osdCount: 512, upmapCount: 1200},
+		{name: "large", pgCount: 65536, osdCount: 2048, upmapCount: 4800},
+	} {
+		fixture := makeBenchmarkFixtureWithUpmaps(tt.pgCount, tt.osdCount, tt.upmapCount)
+		imports := makeSyntheticImportMappings(tt.upmapCount, tt.osdCount)
+
+		b.Run(tt.name, func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				b.StopTimer()
+				resetBenchmarkGlobals()
+				installFixture(fixture)
+				M = mustGetCurrentMappingState()
+				b.StartTimer()
+
+				for _, m := range imports {
+					pui := M.findOrMakeUpmapItem(m.PgID)
+					found := false
+					for _, puiM := range pui.Mappings {
+						if puiM.From == m.Mapping.From {
+							M.mustRemap(m.PgID, puiM.To, m.Mapping.To)
+							found = true
+							break
+						}
+					}
+					if !found {
+						M.mustRemap(m.PgID, m.Mapping.From, m.Mapping.To)
+					}
+				}
+			}
+		})
+	}
+}
+
+func BenchmarkExportMappings(b *testing.B) {
+	for _, tt := range []struct {
+		name       string
+		pgCount    int
+		osdCount   int
+		upmapCount int
+	}{
+		{name: "small", pgCount: 4096, osdCount: 128, upmapCount: 300},
+		{name: "medium", pgCount: 16384, osdCount: 512, upmapCount: 1200},
+		{name: "large", pgCount: 65536, osdCount: 2048, upmapCount: 4800},
+	} {
+		fixture := makeBenchmarkFixtureWithUpmaps(tt.pgCount, tt.osdCount, tt.upmapCount)
+
+		b.Run(tt.name, func(b *testing.B) {
+			b.ReportAllocs()
+
+			for i := 0; i < b.N; i++ {
+				b.StopTimer()
+				resetBenchmarkGlobals()
+				installFixture(fixture)
+				M = mustGetCurrentMappingState()
+
+				filters := make([]mappingFilter, 0, 16)
+				for osd := 0; osd < 8 && osd < tt.osdCount; osd++ {
+					filters = append(filters, withFrom(osd), withTo(osd))
+				}
+				b.StartTimer()
+
+				mappings := M.getMappings(mfOr(filters...))
+
+				wholePgFilters := make([]mappingFilter, 0, len(mappings))
+				for _, mp := range mappings {
+					wholePgFilters = append(wholePgFilters, withPgid(mp.PgID))
+				}
+				_ = M.getMappings(mfOr(wholePgFilters...))
+			}
+		})
+	}
+}
+
+func BenchmarkRemapSingle(b *testing.B) {
+	for _, tt := range []struct {
+		name     string
+		pgCount  int
+		osdCount int
+	}{
+		{name: "small", pgCount: 4096, osdCount: 128},
+		{name: "medium", pgCount: 16384, osdCount: 512},
+		{name: "large", pgCount: 65536, osdCount: 2048},
+	} {
+		fixture := makeBenchmarkFixture(tt.pgCount, tt.osdCount)
+
+		b.Run(tt.name, func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				b.StopTimer()
+				resetBenchmarkGlobals()
+				installFixture(fixture)
+				M = mustGetCurrentMappingState()
+
+				from := (13 + i) % tt.osdCount
+				to := (from + 17) % tt.osdCount
+				if to == from {
+					to = (to + 1) % tt.osdCount
+				}
+				b.StartTimer()
+
+				M.mustRemap("1.0", from, to)
+			}
+		})
+	}
+}
+
+func BenchmarkGenerateCrushChangeMappings(b *testing.B) {
+	for _, tt := range []struct {
+		name     string
+		pgCount  int
+		osdCount int
+	}{
+		{name: "small", pgCount: 4096, osdCount: 128},
+		{name: "medium", pgCount: 16384, osdCount: 512},
+		{name: "large", pgCount: 65536, osdCount: 2048},
+	} {
+		out := makeSyntheticCrushDiffOutput(tt.pgCount, tt.osdCount)
+
+		b.Run(tt.name, func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				b.StopTimer()
+				resetBenchmarkGlobals()
+				runCrushCmp = func(_ string) (string, error) { return out, nil }
+				b.StartTimer()
+
+				_, _ = crushCmp("synthetic")
+			}
+		})
+	}
+}

--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -247,11 +247,10 @@ func BenchmarkMustGetCurrentMappingState(b *testing.B) {
 
 		b.Run(tt.name, func(b *testing.B) {
 			b.ReportAllocs()
+			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
-				b.StopTimer()
 				resetBenchmarkGlobals()
 				installFixture(fixture)
-				b.StartTimer()
 
 				_ = mustGetCurrentMappingState()
 			}
@@ -280,12 +279,11 @@ func BenchmarkCalcPgMappingsToUndoBackfill(b *testing.B) {
 			includedPools := map[int]struct{}{}
 			pgsIncludingOsds := map[int]struct{}{}
 
+			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
-				b.StopTimer()
 				resetBenchmarkGlobals()
 				installFixture(fixture)
 				M = mustGetCurrentMappingState()
-				b.StartTimer()
 
 				calcPgMappingsToUndoBackfill(
 					true,
@@ -321,13 +319,12 @@ func BenchmarkCalcPgMappingsToDrainOsd(b *testing.B) {
 
 		b.Run(tt.name, func(b *testing.B) {
 			b.ReportAllocs()
+			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
-				b.StopTimer()
 				resetBenchmarkGlobals()
 				installFixture(fixture)
 				M = mustGetCurrentMappingState()
 				M.bs.maxBackfillsFrom = 4096
-				b.StartTimer()
 
 				calcPgMappingsToDrainOsd("", []int{0}, targets)
 			}
@@ -355,13 +352,12 @@ func BenchmarkCalcPgMappingsToUndoUpmaps(b *testing.B) {
 
 		b.Run(tt.name, func(b *testing.B) {
 			b.ReportAllocs()
+			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
-				b.StopTimer()
 				resetBenchmarkGlobals()
 				installFixture(fixture)
 				M = mustGetCurrentMappingState()
 				M.bs.maxBackfillsFrom = 4096
-				b.StartTimer()
 
 				calcPgMappingsToUndoUpmaps(osds, false)
 			}
@@ -388,12 +384,11 @@ func BenchmarkCalcPgMappingsToBalanceOsds(b *testing.B) {
 
 		b.Run(tt.name, func(b *testing.B) {
 			b.ReportAllocs()
+			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
-				b.StopTimer()
 				resetBenchmarkGlobals()
 				installFixture(fixture)
 				M = mustGetCurrentMappingState()
-				b.StartTimer()
 
 				calcPgMappingsToBalanceOsds(osds, 64, 1)
 			}
@@ -417,12 +412,11 @@ func BenchmarkImportMappingsLoop(b *testing.B) {
 
 		b.Run(tt.name, func(b *testing.B) {
 			b.ReportAllocs()
+			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
-				b.StopTimer()
 				resetBenchmarkGlobals()
 				installFixture(fixture)
 				M = mustGetCurrentMappingState()
-				b.StartTimer()
 
 				for _, m := range imports {
 					pui := M.findOrMakeUpmapItem(m.PgID)
@@ -459,8 +453,8 @@ func BenchmarkExportMappings(b *testing.B) {
 		b.Run(tt.name, func(b *testing.B) {
 			b.ReportAllocs()
 
+			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
-				b.StopTimer()
 				resetBenchmarkGlobals()
 				installFixture(fixture)
 				M = mustGetCurrentMappingState()
@@ -469,7 +463,6 @@ func BenchmarkExportMappings(b *testing.B) {
 				for osd := 0; osd < 8 && osd < tt.osdCount; osd++ {
 					filters = append(filters, withFrom(osd), withTo(osd))
 				}
-				b.StartTimer()
 
 				mappings := M.getMappings(mfOr(filters...))
 
@@ -497,18 +490,27 @@ func BenchmarkRemapSingle(b *testing.B) {
 
 		b.Run(tt.name, func(b *testing.B) {
 			b.ReportAllocs()
+			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
-				b.StopTimer()
 				resetBenchmarkGlobals()
 				installFixture(fixture)
 				M = mustGetCurrentMappingState()
 
-				from := (13 + i) % tt.osdCount
+				pgb, ok := M.bs.pgbs["1.0"]
+				if !ok || len(pgb.Up) == 0 {
+					b.Fatalf("missing benchmark PG 1.0 or empty up set")
+				}
+
+				from := pgb.Up[i%len(pgb.Up)]
 				to := (from + 17) % tt.osdCount
+				for _, upOsd := range pgb.Up {
+					if to == upOsd {
+						to = (to + 1) % tt.osdCount
+					}
+				}
 				if to == from {
 					to = (to + 1) % tt.osdCount
 				}
-				b.StartTimer()
 
 				M.mustRemap("1.0", from, to)
 			}
@@ -530,11 +532,10 @@ func BenchmarkGenerateCrushChangeMappings(b *testing.B) {
 
 		b.Run(tt.name, func(b *testing.B) {
 			b.ReportAllocs()
+			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
-				b.StopTimer()
 				resetBenchmarkGlobals()
 				runCrushCmp = func(_ string) (string, error) { return out, nil }
-				b.StartTimer()
 
 				_, _ = crushCmp("synthetic")
 			}

--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -18,6 +18,8 @@ func resetBenchmarkGlobals() {
 	savedOsdPoolsDetails = nil
 	savedParsedOsdTree = nil
 	savedPgDumpPgsBrief = nil
+	savedPgUpmapItemMap = nil
+	savedPgUpmapItemMapSource = nil
 
 	M = nil
 }
@@ -45,7 +47,7 @@ func makeOsdDumpJSON(osdCount int) string {
 	var b strings.Builder
 	b.Grow(osdCount * 40)
 	b.WriteString("{\n  \"osds\": [\n")
-	for i := 0; i < osdCount; i++ {
+	for i := range osdCount {
 		if i > 0 {
 			b.WriteString(",\n")
 		}
@@ -63,7 +65,7 @@ func makeOsdDumpJSONWithUpmaps(osdCount int, upmapCount int) string {
 	var b strings.Builder
 	b.Grow(osdCount*40 + upmapCount*80)
 	b.WriteString("{\n  \"osds\": [\n")
-	for i := 0; i < osdCount; i++ {
+	for i := range osdCount {
 		if i > 0 {
 			b.WriteString(",\n")
 		}
@@ -102,7 +104,7 @@ func makeOsdTreeJSON(osdCount int, osdsPerHost int) string {
 	b.Grow(osdCount * 50)
 	b.WriteString("{\n  \"nodes\": [\n")
 	b.WriteString("    { \"id\": -1, \"name\": \"default\", \"type\": \"root\", \"children\": [")
-	for h := 0; h < hostCount; h++ {
+	for h := range hostCount {
 		if h > 0 {
 			b.WriteString(",")
 		}
@@ -110,15 +112,12 @@ func makeOsdTreeJSON(osdCount int, osdsPerHost int) string {
 	}
 	b.WriteString("] },\n")
 
-	for h := 0; h < hostCount; h++ {
+	for h := range hostCount {
 		if h > 0 {
 			b.WriteString(",\n")
 		}
 		start := h * osdsPerHost
-		end := start + osdsPerHost
-		if end > osdCount {
-			end = osdCount
-		}
+		end := min(start+osdsPerHost, osdCount)
 		fmt.Fprintf(&b, "    { \"id\": %d, \"name\": \"host%d\", \"type\": \"host\", \"children\": [", -1000-h, h)
 		for i := start; i < end; i++ {
 			if i > start {
@@ -129,7 +128,7 @@ func makeOsdTreeJSON(osdCount int, osdsPerHost int) string {
 		b.WriteString("] }")
 	}
 
-	for i := 0; i < osdCount; i++ {
+	for i := range osdCount {
 		b.WriteString(",\n")
 		fmt.Fprintf(&b, "    { \"id\": %d, \"name\": \"osd.%d\", \"type\": \"osd\", \"reweight\": 1.0 }", i, i)
 	}
@@ -141,7 +140,7 @@ func makePgDumpJSON(pgCount int, osdCount int) string {
 	var b strings.Builder
 	b.Grow(pgCount * 130)
 	b.WriteString("[\n")
-	for i := 0; i < pgCount; i++ {
+	for i := range pgCount {
 		if i > 0 {
 			b.WriteString(",\n")
 		}
@@ -198,20 +197,20 @@ func makeBenchmarkFixtureWithUpmaps(pgCount int, osdCount int, upmapCount int) b
 }
 
 func makeSyntheticImportMappings(count int, osdCount int) []pgMapping {
-	out := make([]pgMapping, 0, count)
-	for i := 0; i < count; i++ {
+	out := make([]pgMapping, count)
+	for i := range count {
 		from := (i + 13) % osdCount
 		to := (from + 17) % osdCount
 		if to == from {
 			to = (to + 1) % osdCount
 		}
-		out = append(out, pgMapping{
+		out[i] = pgMapping{
 			PgID: fmt.Sprintf("1.%x", i),
 			Mapping: mapping{
 				From: from,
 				To:   to,
 			},
-		})
+		}
 	}
 	return out
 }
@@ -220,7 +219,7 @@ func makeSyntheticCrushDiffOutput(pgCount int, osdCount int) string {
 	var b strings.Builder
 	b.Grow(pgCount * 60)
 	b.WriteString("# synthetic crushdiff output\n")
-	for i := 0; i < pgCount; i++ {
+	for i := range pgCount {
 		a0 := i % osdCount
 		a1 := (i + 7) % osdCount
 		a2 := (i + 13) % osdCount

--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
 	"strings"
 	"testing"
@@ -136,15 +137,9 @@ func makeOsdTreeJSON(osdCount int, osdsPerHost int) string {
 	return b.String()
 }
 
-func makePgDumpJSON(pgCount int, osdCount int) string {
-	var b strings.Builder
-	b.Grow(pgCount * 130)
-	b.WriteString("[\n")
+func makeBenchmarkPgStats(pgCount int, osdCount int) []*pgBriefItem {
+	pgStats := make([]*pgBriefItem, 0, pgCount)
 	for i := range pgCount {
-		if i > 0 {
-			b.WriteString(",\n")
-		}
-
 		a0 := i % osdCount
 		a1 := (i + 7) % osdCount
 		a2 := (i + 13) % osdCount
@@ -161,17 +156,35 @@ func makePgDumpJSON(pgCount int, osdCount int) string {
 			state = "active+remapped+backfill_wait"
 		}
 
-		fmt.Fprintf(
-			&b,
-			" { \"pgid\": \"1.%x\", \"up\": [ %d, %d, %d ], \"acting\": [ %d, %d, %d ], \"state\": \"%s\" }",
-			i,
-			u0, u1, u2,
-			a0, a1, a2,
-			state,
-		)
+		pgStats = append(pgStats, &pgBriefItem{
+			PgID:   fmt.Sprintf("1.%x", i),
+			State:  state,
+			Up:     []int{u0, u1, u2},
+			Acting: []int{a0, a1, a2},
+		})
 	}
-	b.WriteString("\n]\n")
-	return b.String()
+
+	return pgStats
+}
+
+func makePgDumpJSON(pgCount int, osdCount int) string {
+	pgStats := makeBenchmarkPgStats(pgCount, osdCount)
+
+	out, err := json.Marshal(pgBriefNautilus{PgStats: pgStats})
+	if err != nil {
+		panic(err)
+	}
+	return string(out)
+}
+
+func makePgDumpJSONLegacy(pgCount int, osdCount int) string {
+	pgStats := makeBenchmarkPgStats(pgCount, osdCount)
+
+	out, err := json.Marshal(pgStats)
+	if err != nil {
+		panic(err)
+	}
+	return string(out)
 }
 
 func makeBenchmarkFixture(pgCount int, osdCount int) benchmarkFixture {
@@ -181,6 +194,12 @@ func makeBenchmarkFixture(pgCount int, osdCount int) benchmarkFixture {
 		osdTree: makeOsdTreeJSON(osdCount, 8),
 		poolLs:  makePoolJSON(),
 	}
+}
+
+func makeBenchmarkFixtureLegacy(pgCount int, osdCount int) benchmarkFixture {
+	f := makeBenchmarkFixture(pgCount, osdCount)
+	f.pgDump = makePgDumpJSONLegacy(pgCount, osdCount)
+	return f
 }
 
 func makeBenchmarkFixtureWithUpmaps(pgCount int, osdCount int, upmapCount int) benchmarkFixture {
@@ -243,6 +262,31 @@ func BenchmarkMustGetCurrentMappingState(b *testing.B) {
 		{name: "large", pgCount: 65536, osdCount: 2048},
 	} {
 		fixture := makeBenchmarkFixture(tt.pgCount, tt.osdCount)
+
+		b.Run(tt.name, func(b *testing.B) {
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				resetBenchmarkGlobals()
+				installFixture(fixture)
+
+				_ = mustGetCurrentMappingState()
+			}
+		})
+	}
+}
+
+func BenchmarkMustGetCurrentMappingStateLegacyJSON(b *testing.B) {
+	for _, tt := range []struct {
+		name     string
+		pgCount  int
+		osdCount int
+	}{
+		{name: "small", pgCount: 4096, osdCount: 128},
+		{name: "medium", pgCount: 16384, osdCount: 512},
+		{name: "large", pgCount: 65536, osdCount: 2048},
+	} {
+		fixture := makeBenchmarkFixtureLegacy(tt.pgCount, tt.osdCount)
 
 		b.Run(tt.name, func(b *testing.B) {
 			b.ReportAllocs()

--- a/ceph.go
+++ b/ceph.go
@@ -678,7 +678,7 @@ func parseCrushDiff(in string) ([]*pgUpmapItem, error) {
 		// line mapping should look something like follows:
 		//
 		//  1.0	[3, 7, 8] -> [3, 7, 2]
-		if strings.Index(line, "->") < 0 {
+		if !strings.Contains(line, "->") {
 			continue
 		}
 

--- a/ceph.go
+++ b/ceph.go
@@ -21,7 +21,7 @@ import (
 	"fmt"
 	"math"
 	"regexp"
-	"sort"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -42,7 +42,6 @@ var (
 	runCrushCmp       = func(path string) (string, error) { return runCombined("crushdiff", "compare", path, "--verbose") }
 
 	pgQueryPeerRegexp = regexp.MustCompile(`(?P<osd>[0-9]+)(?:\((?P<index>[0-9]+)\))?`)
-	pgIdRegexp        = regexp.MustCompile(`(?P<pool>[0-9]+)\.(?P<id>[0-9a-f]+)`)
 )
 
 type pgUpmapItem struct {
@@ -95,6 +94,9 @@ type osdPoolDetail struct {
 
 type poolsDetails struct {
 	Pools map[int]*osdPoolDetail
+	// UsesEC caches whether each pool ID is erasure-coded, computed once at
+	// build time so PgUsesEC doesn't need to re-evaluate ECProfile on every call.
+	UsesEC map[int]bool
 }
 
 type parsedOsdTree struct {
@@ -289,23 +291,26 @@ func (pui *pgUpmapItem) do() {
 
 	cmd := []string{"ceph", "osd", "pg-upmap-items", pui.PgID}
 	for _, m := range pui.Mappings {
-		cmd = append(cmd, fmt.Sprintf("%d", m.From), fmt.Sprintf("%d", m.To))
+		cmd = append(cmd, strconv.Itoa(m.From), strconv.Itoa(m.To))
 	}
 	_ = runOrDie(cmd...)
 }
 
 // Detect whether a given PG belongs to an erasure-coded pool
 func (pd *poolsDetails) PgUsesEC(pgid string) bool {
-	m := pgIdRegexp.FindStringSubmatch(pgid)
-	if len(m) != 3 {
+	// PGID format is always "<poolid>.<hex>" — extract the pool ID with a
+	// simple byte scan rather than a regex to avoid per-call allocations.
+	m := strings.IndexByte(pgid, '.')
+	if m <= 0 {
 		panic(fmt.Sprintf("can't parse PGID %s", pgid))
 	}
-	poolId, err := strconv.Atoi(m[1])
+	poolId, err := strconv.Atoi(pgid[:m])
 	if err != nil {
 		panic(fmt.Sprintf("can't parse pool in PGID %s", pgid))
 	}
-	if pool, ok := pd.Pools[poolId]; ok {
-		return pool.ECProfile != ""
+	// UsesEC was precomputed when poolsDetails was built; no string comparison needed here.
+	if usesEC, ok := pd.UsesEC[poolId]; ok {
+		return usesEC
 	}
 	panic(fmt.Sprintf("could not find pool data for PG %s", pgid))
 }
@@ -373,6 +378,8 @@ func countCurrentBackfills() (map[int]int, map[int]int) {
 }
 
 var savedPgDumpPgsBrief []*pgBriefItem
+var savedPgUpmapItemMap map[string]*pgUpmapItem
+var savedPgUpmapItemMapSource *osdDumpOut
 
 func pgDumpPgsBrief() []*pgBriefItem {
 	if len(savedPgDumpPgsBrief) > 0 {
@@ -386,18 +393,29 @@ func pgDumpPgsBrief() []*pgBriefItem {
 
 	var pgBriefs []*pgBriefItem
 
-	if err := json.Unmarshal([]byte(out), &pgBriefs); err != nil {
-		// Newer versions of Ceph have a slightly different structure.
-		var pgBriefNautilusOut pgBriefNautilus
-		if err := json.Unmarshal([]byte(out), &pgBriefNautilusOut); err != nil {
+	// Try Nautilus+ style wrapper first, then fall back to direct array format.
+	var pgBriefNautilusOut pgBriefNautilus
+	if err := json.Unmarshal([]byte(out), &pgBriefNautilusOut); err == nil {
+		pgBriefs = pgBriefNautilusOut.PgStats
+	} else {
+		if err := json.Unmarshal([]byte(out), &pgBriefs); err != nil {
 			panic(errors.WithStack(err))
 		}
-		pgBriefs = pgBriefNautilusOut.PgStats
 	}
 	pgBriefs = sanitizePgBriefs(pgBriefs)
+	pools := osdPoolDetails()
+	upmapItemsByPg := pgUpmapItemMap()
 
 	for _, pgb := range pgBriefs {
-		reorderUpToMatchActing(pgb.PgID, pgb.Up, pgb.Acting, true)
+		// Fast path: if up already matches acting and no upmap item exists
+		// for this PG, reordering cannot change anything.
+		if slices.Equal(pgb.Up, pgb.Acting) {
+			if _, ok := upmapItemsByPg[pgb.PgID]; !ok {
+				continue
+			}
+		}
+
+		reorderUpToMatchActingWithContext(pgb.PgID, pgb.Up, pgb.Acting, true, pools, upmapItemsByPg)
 	}
 
 	savedPgDumpPgsBrief = pgBriefs
@@ -406,7 +424,8 @@ func pgDumpPgsBrief() []*pgBriefItem {
 
 func sanitizePgBriefs(pgBriefs []*pgBriefItem) []*pgBriefItem {
 	duplicateMessage := "WARNING: PG %s's %s set has one or more duplicated OSD IDs; this PG will be excluded from operations and reservation calculations. Please check your CRUSH rules and map.\n"
-	sanitized := make([]*pgBriefItem, 0, len(pgBriefs))
+	sanitized := pgBriefs
+	i := 0
 
 	for _, pgBrief := range pgBriefs {
 		if len(pgBrief.Up) != len(pgBrief.Acting) {
@@ -424,38 +443,25 @@ func sanitizePgBriefs(pgBriefs []*pgBriefItem) []*pgBriefItem {
 			continue
 		}
 
-		sanitized = append(sanitized, pgBrief)
+		sanitized[i] = pgBrief
+		i++
 	}
 
-	return sanitized
+	return sanitized[:i]
 }
 
 func hasDuplicateOSDID(osdids []int) bool {
-	for i, osdid := range osdids {
+	seen := make(map[int]struct{}, len(osdids))
+	for _, osdid := range osdids {
 		if osdid == invalidOSD {
 			continue
 		}
-		for j, otherOSDID := range osdids {
-			if i == j {
-				continue
-			}
-			if osdid == otherOSDID {
-				return true
-			}
+		if _, ok := seen[osdid]; ok {
+			return true
 		}
+		seen[osdid] = struct{}{}
 	}
 	return false
-}
-
-func pgBriefMap() map[string]*pgBriefItem {
-	pgBriefs := pgDumpPgsBrief()
-
-	pgBriefMap := make(map[string]*pgBriefItem)
-	for _, pgb := range pgBriefs {
-		pgBriefMap[pgb.PgID] = pgb
-	}
-
-	return pgBriefMap
 }
 
 // Re-order the up list so that any OSDs in it that are also in the
@@ -465,16 +471,27 @@ func pgBriefMap() map[string]*pgBriefItem {
 // matters and won't change, but for replicated pools the order can
 // change and this doesn't imply data movement.
 func reorderUpToMatchActing(pgid string, up, acting []int, useUpmap bool) {
+	reorderUpToMatchActingWithContext(pgid, up, acting, useUpmap, nil, nil)
+}
+
+func reorderUpToMatchActingWithContext(pgid string, up, acting []int, useUpmap bool, pools *poolsDetails, upmapItemsByPg map[string]*pgUpmapItem) {
 	// Do not reorder if the PG belongs to an Erasure-Coded pool,
 	// since order DOES matter and will trigger backfills.
-	pools := osdPoolDetails()
+	if pools == nil {
+		pools = osdPoolDetails()
+	}
 	if pools.PgUsesEC(pgid) {
 		return
 	}
 
-	mappings := make(map[int]int)
+	// Keep nil unless we actually have upmap entries for this PG.
+	// Lookups on a nil map are safe and return (zero, false).
+	var mappings map[int]int
 	if useUpmap {
-		if pui, ok := pgUpmapItemMap()[pgid]; ok {
+		if upmapItemsByPg == nil {
+			upmapItemsByPg = pgUpmapItemMap()
+		}
+		if pui, ok := upmapItemsByPg[pgid]; ok {
 			mappings = pui.mappingsAsToFromMap()
 		}
 	}
@@ -523,13 +540,19 @@ func osdDump() *osdDumpOut {
 
 func pgUpmapItemMap() map[string]*pgUpmapItem {
 	osdDumpOut := osdDump()
+	if savedPgUpmapItemMap != nil && savedPgUpmapItemMapSource == osdDumpOut {
+		return savedPgUpmapItemMap
+	}
 
-	puis := make(map[string]*pgUpmapItem)
+	puis := make(map[string]*pgUpmapItem, len(osdDumpOut.PgUpmapItems))
 	for _, pui := range osdDumpOut.PgUpmapItems {
 		puis[pui.PgID] = pui
 	}
 
-	return puis
+	savedPgUpmapItemMap = puis
+	savedPgUpmapItemMapSource = osdDumpOut
+
+	return savedPgUpmapItemMap
 }
 
 var savedParsedOsdTree *parsedOsdTree
@@ -592,11 +615,13 @@ func osdPoolDetails() *poolsDetails {
 	mustParseCephCommand(jsonOut, err, &pools)
 
 	poolsMap = make(map[int]*osdPoolDetail)
+	usesEC := make(map[int]bool, len(pools))
 	for _, pool := range pools {
 		poolsMap[pool.ID] = pool
+		usesEC[pool.ID] = pool.ECProfile != ""
 	}
 
-	savedOsdPoolsDetails = &poolsDetails{Pools: poolsMap}
+	savedOsdPoolsDetails = &poolsDetails{Pools: poolsMap, UsesEC: usesEC}
 	return savedOsdPoolsDetails
 }
 
@@ -653,7 +678,7 @@ func parseCrushDiff(in string) ([]*pgUpmapItem, error) {
 		// line mapping should look something like follows:
 		//
 		//  1.0	[3, 7, 8] -> [3, 7, 2]
-		if !strings.Contains(line, "->") {
+		if strings.Index(line, "->") < 0 {
 			continue
 		}
 
@@ -674,7 +699,7 @@ func parseCrushDiff(in string) ([]*pgUpmapItem, error) {
 		puis = append(puis, pui)
 	}
 
-	sort.Slice(puis, func(i, j int) bool { return puis[i].PgID < puis[j].PgID })
+	slices.SortFunc(puis, func(a, b *pgUpmapItem) int { return strings.Compare(a.PgID, b.PgID) })
 	return puis, nil
 }
 
@@ -725,12 +750,12 @@ func parsePGRemapEntry(entry string) (*pgUpmapItem, error) {
 		return nil, fmt.Errorf("unequal count between existing and new OSD sets within mapping: %q", entry)
 	}
 
-	enM := make([]mapping, 0, len(nM))
+	enM := make([]mapping, len(nM))
 	for i := range nM {
-		enM = append(enM, mapping{
+		enM[i] = mapping{
 			From: eM[i],
 			To:   nM[i],
-		})
+		}
 	}
 
 	return &pgUpmapItem{
@@ -762,8 +787,16 @@ func parseCephCommand(out string, err error, v any) error {
 // the json spec or the golang parser (though it is apparently allowed by the
 // Python parser), so we convert such cases to "null".
 func handleCephInf(buf []byte) []byte {
-	buf = bytes.ReplaceAll(buf, []byte("\": inf"), []byte("\": null"))
-	buf = bytes.ReplaceAll(buf, []byte("\":inf"), []byte("\":null"))
-
+	// bytes.ReplaceAll always allocates a new buffer, even when the search
+	// pattern is not present. Guard each replacement with a Contains check
+	// so that the common case (no "inf" values) avoids the allocation entirely.
+	for _, pair := range [][2][]byte{
+		{[]byte("\": inf"), []byte("\": null")},
+		{[]byte("\":inf"), []byte("\":null")},
+	} {
+		if bytes.Contains(buf, pair[0]) {
+			buf = bytes.ReplaceAll(buf, pair[0], pair[1])
+		}
+	}
 	return buf
 }

--- a/ceph_test.go
+++ b/ceph_test.go
@@ -15,10 +15,74 @@
 package main
 
 import (
+	"math"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 )
+
+func TestHasDuplicateOSDID(t *testing.T) {
+	for _, tt := range []struct {
+		name   string
+		osdids []int
+		want   bool
+	}{
+		{
+			name:   "nil slice",
+			osdids: nil,
+			want:   false,
+		},
+		{
+			name:   "empty slice",
+			osdids: []int{},
+			want:   false,
+		},
+		{
+			name:   "single element",
+			osdids: []int{7},
+			want:   false,
+		},
+		{
+			name:   "non duplicate normal values",
+			osdids: []int{1, 2, 3},
+			want:   false,
+		},
+		{
+			name:   "duplicate normal values",
+			osdids: []int{1, 2, 1},
+			want:   true,
+		},
+		{
+			name:   "invalid sentinel only",
+			osdids: []int{invalidOSD, invalidOSD, invalidOSD},
+			want:   false,
+		},
+		{
+			name:   "mixed invalid sentinel and duplicate value",
+			osdids: []int{invalidOSD, 7, invalidOSD, 7},
+			want:   true,
+		},
+		{
+			name:   "negative values no duplicate",
+			osdids: []int{-1, -2, -3},
+			want:   false,
+		},
+		{
+			name:   "negative values with duplicate",
+			osdids: []int{-1, -2, -1},
+			want:   true,
+		},
+		{
+			name:   "large int values with duplicate",
+			osdids: []int{math.MaxInt, 42, math.MaxInt},
+			want:   true,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, hasDuplicateOSDID(tt.osdids))
+		})
+	}
+}
 
 func TestParseCrushDiff(t *testing.T) {
 	for _, tt := range []struct {
@@ -169,8 +233,155 @@ osdmaptool: osdmap file '/tmp/tmp5ip_axby/osdmap'
 			}
 
 			items, err := crushCmp("")
-			require.Nil(t, err)
-			require.Equal(t, items, tt.items)
+			require.NoError(t, err)
+			require.Equal(t, tt.items, items)
+		})
+	}
+}
+
+func resetCephStateForCacheTest() {
+	savedOsdDumpOut = nil
+	savedOsdPoolsDetails = nil
+	savedParsedOsdTree = nil
+	savedPgDumpPgsBrief = nil
+	savedPgUpmapItemMap = nil
+	savedPgUpmapItemMapSource = nil
+}
+
+func TestPgUpmapItemMapCacheInvalidatesAfterOsdDumpReset(t *testing.T) {
+	resetCephStateForCacheTest()
+	defer teardownTest(t)
+
+	variant := 1
+	runOsdDump = func() (string, error) {
+		if variant == 1 {
+			return `{"pg_upmap_items":[{"pgid":"1.1","mappings":[{"from":10,"to":11}]}]}`, nil
+		}
+		return `{"pg_upmap_items":[{"pgid":"1.2","mappings":[{"from":20,"to":21}]}]}`, nil
+	}
+
+	first := pgUpmapItemMap()
+	require.Contains(t, first, "1.1")
+	require.NotContains(t, first, "1.2")
+
+	variant = 2
+
+	// Without resetting osdDump cache, map should still be the same cached view.
+	second := pgUpmapItemMap()
+	require.Equal(t, first, second)
+	require.Contains(t, second, "1.1")
+	require.NotContains(t, second, "1.2")
+
+	// Resetting osdDump cache should force a fresh map build from new dump content.
+	savedOsdDumpOut = nil
+	third := pgUpmapItemMap()
+	require.NotEqual(t, first, third)
+	require.Contains(t, third, "1.2")
+	require.NotContains(t, third, "1.1")
+}
+
+func TestPgDumpPgsBriefReordersUsingUpmapMappings(t *testing.T) {
+	resetCephStateForCacheTest()
+	defer teardownTest(t)
+
+	runOsdPoolLs = func() (string, error) {
+		return `[
+			{"pool_id": 1, "pool_name": "replicated", "erasure_code_profile": ""}
+		]`, nil
+	}
+	runOsdDump = func() (string, error) {
+		return `{
+			"pg_upmap_items": [
+				{"pgid":"1.1","mappings":[{"from":4,"to":2}]},
+				{"pgid":"1.2","mappings":[{"from":8,"to":6}]}
+			]
+		}`, nil
+	}
+	runPgDumpPgsBrief = func() (string, error) {
+		return `[
+			{"pgid":"1.1","state":"active","up":[1,3,2],"acting":[1,4,3]},
+			{"pgid":"1.2","state":"active","up":[5,7,6],"acting":[5,8,7]}
+		]`, nil
+	}
+
+	pgBriefs := pgDumpPgsBrief()
+	require.Len(t, pgBriefs, 2)
+	require.Equal(t, []int{1, 2, 3}, pgBriefs[0].Up)
+	require.Equal(t, []int{5, 6, 7}, pgBriefs[1].Up)
+}
+
+func TestPgDumpPgsBriefDoesNotReorderECPools(t *testing.T) {
+	resetCephStateForCacheTest()
+	defer teardownTest(t)
+
+	runOsdPoolLs = func() (string, error) {
+		return `[
+			{"pool_id": 2, "pool_name": "ec", "erasure_code_profile": "ec-profile"}
+		]`, nil
+	}
+	runOsdDump = func() (string, error) {
+		return `{
+			"pg_upmap_items": [
+				{"pgid":"2.1","mappings":[{"from":4,"to":2}]}
+			]
+		}`, nil
+	}
+	runPgDumpPgsBrief = func() (string, error) {
+		return `[
+			{"pgid":"2.1","state":"active","up":[1,3,2],"acting":[1,4,3]}
+		]`, nil
+	}
+
+	pgBriefs := pgDumpPgsBrief()
+	require.Len(t, pgBriefs, 1)
+	// EC pool ordering must be preserved exactly.
+	require.Equal(t, []int{1, 3, 2}, pgBriefs[0].Up)
+}
+
+func TestPgDumpPgsBriefParsesBothJSONShapes(t *testing.T) {
+	tests := []struct {
+		name string
+		out  string
+	}{
+		{
+			name: "array",
+			out: `[
+				{"pgid":"1.1","state":"active","up":[1,2,3],"acting":[1,2,3]},
+				{"pgid":"1.2","state":"active","up":[4,5,6],"acting":[4,5,6]}
+			]`,
+		},
+		{
+			name: "nautilus+",
+			out: `{
+				"pg_stats": [
+					{"pgid":"1.1","state":"active","up":[1,2,3],"acting":[1,2,3]},
+					{"pgid":"1.2","state":"active","up":[4,5,6],"acting":[4,5,6]}
+				]
+			}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resetCephStateForCacheTest()
+			defer teardownTest(t)
+
+			runOsdPoolLs = func() (string, error) {
+				return `[
+					{"pool_id": 1, "pool_name": "replicated", "erasure_code_profile": ""}
+				]`, nil
+			}
+			runOsdDump = func() (string, error) {
+				return `{"pg_upmap_items": []}`, nil
+			}
+			runPgDumpPgsBrief = func() (string, error) {
+				return tt.out, nil
+			}
+
+			pgBriefs := pgDumpPgsBrief()
+			require.Len(t, pgBriefs, 2)
+			require.Equal(t, "1.1", pgBriefs[0].PgID)
+			require.Equal(t, "1.2", pgBriefs[1].PgID)
 		})
 	}
 }

--- a/main.go
+++ b/main.go
@@ -957,8 +957,9 @@ func getCandidateMappings(
 	tree := osdTree()
 	sourceOsdNode := tree.IDToNode[sourceOsd]
 	pgs := getUpPGsForOsds([]int{sourceOsd})
-	candidateMappings := []pgMapping{}
-	for _, pg := range pgs[sourceOsd] {
+	sourcePGs := pgs[sourceOsd]
+	candidateMappings := make([]pgMapping, 0, len(sourcePGs)*len(targetOsds))
+	for _, pg := range sourcePGs {
 		for _, targetOsd := range targetOsds {
 			if !isCandidateMapping(
 				allowMovementAcrossCrushType,

--- a/main.go
+++ b/main.go
@@ -337,12 +337,8 @@ mapping), unless --whole-pg is specified.
 				if err != nil {
 					panic(err)
 				}
+				defer f.Close()
 
-				defer func() {
-					if err := f.Close(); err != nil {
-						panic(err)
-					}
-				}()
 				writer = f
 			}
 
@@ -404,11 +400,7 @@ cluster undergoes some other major changes).
 				if err != nil {
 					panic(err)
 				}
-				defer func() {
-					if err := f.Close(); err != nil {
-						panic(err)
-					}
-				}()
+				defer f.Close()
 
 				writer = f
 			}
@@ -460,12 +452,7 @@ JSON format example, remapping PG 1.1 from OSD 100 to OSD 42:
 				if err != nil {
 					panic(err)
 				}
-
-				defer func() {
-					if err := f.Close(); err != nil {
-						panic(err)
-					}
-				}()
+				defer f.Close()
 				reader = f
 			}
 
@@ -845,7 +832,7 @@ func calcPgMappingsToUndoBackfill(excludeBackfilling, source, target bool, exclu
 								continue
 							}
 
-							if !included(up[i]) && !included(acting[i]) {
+							if !(included(up[i]) || included(acting[i])) {
 								continue
 							}
 						} else {
@@ -855,7 +842,7 @@ func calcPgMappingsToUndoBackfill(excludeBackfilling, source, target bool, exclu
 								continue
 							}
 
-							if (!source || !included(up[i])) && (!target || !included(acting[i])) {
+							if !(source && included(up[i]) || target && included(acting[i])) {
 								continue
 							}
 						}

--- a/main.go
+++ b/main.go
@@ -337,8 +337,12 @@ mapping), unless --whole-pg is specified.
 				if err != nil {
 					panic(err)
 				}
-				defer f.Close()
 
+				defer func() {
+					if err := f.Close(); err != nil {
+						panic(err)
+					}
+				}()
 				writer = f
 			}
 
@@ -400,7 +404,11 @@ cluster undergoes some other major changes).
 				if err != nil {
 					panic(err)
 				}
-				defer f.Close()
+				defer func() {
+					if err := f.Close(); err != nil {
+						panic(err)
+					}
+				}()
 
 				writer = f
 			}
@@ -452,7 +460,12 @@ JSON format example, remapping PG 1.1 from OSD 100 to OSD 42:
 				if err != nil {
 					panic(err)
 				}
-				defer f.Close()
+
+				defer func() {
+					if err := f.Close(); err != nil {
+						panic(err)
+					}
+				}()
 				reader = f
 			}
 
@@ -832,7 +845,7 @@ func calcPgMappingsToUndoBackfill(excludeBackfilling, source, target bool, exclu
 								continue
 							}
 
-							if !(included(up[i]) || included(acting[i])) {
+							if !included(up[i]) && !included(acting[i]) {
 								continue
 							}
 						} else {
@@ -842,7 +855,7 @@ func calcPgMappingsToUndoBackfill(excludeBackfilling, source, target bool, exclu
 								continue
 							}
 
-							if !(source && included(up[i]) || target && included(acting[i])) {
+							if (!source || !included(up[i])) && (!target || !included(acting[i])) {
 								continue
 							}
 						}

--- a/main.go
+++ b/main.go
@@ -758,10 +758,29 @@ func calcPgMappingsToUndoBackfill(excludeBackfilling, source, target bool, exclu
 		return len(includedOsds) == 0 || ok
 	}
 
+	type remapRequest struct {
+		pgid string
+		from int
+		to   int
+	}
+
 	// Run these concurrently in case they need to go to pgQuery, which is
 	// quite slow.
 	wg := sync.WaitGroup{}
 	ch := make(chan *pgBriefItem)
+
+	// Apply remaps through a single goroutine so mapping state mutations keep
+	// the same semantics while removing producer-side lock contention.
+	remapCh := make(chan remapRequest, concurrency*64)
+	remapDone := make(chan struct{})
+	go func() {
+		defer close(remapDone)
+		for r := range remapCh {
+			if err := M.tryRemap(r.pgid, r.from, r.to); err != nil {
+				fmt.Printf("WARNING: %v\n", err)
+			}
+		}
+	}()
 
 	for i := 0; i < concurrency; i++ {
 		wg.Go(func() {
@@ -880,9 +899,10 @@ func calcPgMappingsToUndoBackfill(excludeBackfilling, source, target bool, exclu
 						// actually use the upmap
 						// exception table to cancel
 						// the backfill.
-						err := M.tryRemap(id, up[i], acting[i])
-						if err != nil {
-							fmt.Printf("WARNING: %v\n", err)
+						remapCh <- remapRequest{
+							pgid: id,
+							from: up[i],
+							to:   acting[i],
 						}
 					}
 				}
@@ -897,6 +917,8 @@ func calcPgMappingsToUndoBackfill(excludeBackfilling, source, target bool, exclu
 
 	close(ch)
 	wg.Wait()
+	close(remapCh)
+	<-remapDone
 }
 
 func calcPgMappingsToDrainOsd(

--- a/main.go
+++ b/main.go
@@ -24,7 +24,6 @@ import (
 	"os/exec"
 	"runtime/debug"
 	"slices"
-	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -590,7 +589,7 @@ func mustParseOsdSpec(s string) []int {
 
 func parseOsdSpec(s string) ([]int, error) {
 	errResponse := func(s string) ([]int, error) {
-		return nil, errors.New(fmt.Sprintf("'%s' is not a valid osdspec - see root command --help", s))
+		return nil, fmt.Errorf("'%s' is not a valid osdspec - see root command --help", s)
 	}
 
 	osd, err := strconv.Atoi(s)
@@ -598,16 +597,16 @@ func parseOsdSpec(s string) ([]int, error) {
 		return []int{osd}, nil
 	}
 
-	spl := strings.SplitN(s, ":", 2)
-	if len(spl) != 2 {
+	prefix, bucketName, ok := strings.Cut(s, ":")
+	if !ok {
 		return errResponse(s)
 	}
 
-	if spl[0] != "bucket" {
+	if prefix != "bucket" {
 		return errResponse(s)
 	}
 
-	osds, err := getOsdsForBucket(spl[1], "")
+	osds, err := getOsdsForBucket(bucketName, "")
 	if err != nil {
 		return nil, err
 	}
@@ -671,17 +670,18 @@ func mustParseMaxBackfillReservations(cmd *cobra.Command) {
 		M.bs.maxBackfillReservations = max
 
 		for _, s := range strs[1:] {
-			spl := strings.Split(s, ":")
-			if len(spl) < 2 {
-				panic(errors.WithStack(errors.New(fmt.Sprintf("'%s' is not a valid max-backfill-reservation specifier", s))))
+			// Find the last ':' to split osdspec and max value without allocating a split slice.
+			idx := strings.LastIndex(s, ":")
+			if idx < 0 {
+				panic(errors.WithStack(fmt.Errorf("'%s' is not a valid max-backfill-reservation specifier", s)))
 			}
 
-			max, err := strconv.Atoi(spl[len(spl)-1])
+			max, err := strconv.Atoi(s[idx+1:])
 			if err != nil {
 				panic(errors.WithStack(err))
 			}
 
-			osds := mustParseOsdSpec(s[0:strings.LastIndex(s, ":")])
+			osds := mustParseOsdSpec(s[:idx])
 			for _, osd := range osds {
 				M.bs.osd(osd).maxBackfillReservations = max
 			}
@@ -769,7 +769,14 @@ func calcPgMappingsToUndoBackfill(excludeBackfilling, source, target bool, exclu
 				id := pgb.PgID
 				up := pgb.Up
 				acting := pgb.Acting
-				pool, err := strconv.Atoi(strings.Split(id, ".")[0])
+				// PGIDs are "<pool>.<suffix>"; find the separator once so we
+				// can parse just the pool prefix without allocating a split slice.
+				m := strings.IndexByte(id, '.')
+				if m <= 0 {
+					fmt.Printf("Could not parse pool ID from PG %s\n", id)
+					continue
+				}
+				pool, err := strconv.Atoi(id[:m])
 				if err != nil {
 					fmt.Printf("Could not parse pool ID from PG %s: %s\n", id, err)
 					continue
@@ -805,10 +812,18 @@ func calcPgMappingsToUndoBackfill(excludeBackfilling, source, target bool, exclu
 
 				if len(pgsIncludingOsds) > 0 {
 					include := false
-					for _, osd := range append(acting, up...) {
+					for _, osd := range acting {
 						if _, ok := pgsIncludingOsds[osd]; ok {
 							include = true
 							break
+						}
+					}
+					if !include {
+						for _, osd := range up {
+							if _, ok := pgsIncludingOsds[osd]; ok {
+								include = true
+								break
+							}
 						}
 					}
 					if !include {
@@ -889,6 +904,9 @@ func calcPgMappingsToDrainOsd(
 	sourceOsds []int,
 	targetOsds map[int]struct{},
 ) {
+	// targetOsds does not change in this function; materialize once.
+	targetOsdList := mapKeysInt(targetOsds)
+
 	changed := true
 	for changed {
 		changed = false
@@ -896,7 +914,7 @@ func calcPgMappingsToDrainOsd(
 			candidateMappings := getCandidateMappings(
 				allowMovementAcrossCrushType,
 				sourceOsd,
-				mapKeysInt(targetOsds),
+				targetOsdList,
 			)
 
 			if len(candidateMappings) > 0 {
@@ -914,6 +932,8 @@ func getCandidateMappings(
 	sourceOsd int,
 	targetOsds []int,
 ) []pgMapping {
+	tree := osdTree()
+	sourceOsdNode := tree.IDToNode[sourceOsd]
 	pgs := getUpPGsForOsds([]int{sourceOsd})
 	candidateMappings := []pgMapping{}
 	for _, pg := range pgs[sourceOsd] {
@@ -923,6 +943,8 @@ func getCandidateMappings(
 				sourceOsd,
 				targetOsd,
 				pg,
+				tree,
+				sourceOsdNode,
 			) {
 				continue
 			}
@@ -943,13 +965,12 @@ func isCandidateMapping(
 	sourceOsd int,
 	targetOsd int,
 	pg *pgBriefItem,
+	tree *parsedOsdTree,
+	sourceOsdNode *osdTreeNode,
 ) bool {
 	if targetOsd == sourceOsd {
 		return false
 	}
-
-	tree := osdTree()
-	sourceOsdNode := tree.IDToNode[sourceOsd]
 	targetOsdNode := tree.IDToNode[targetOsd]
 
 	if allowMovementAcrossCrushType == "" {
@@ -1205,7 +1226,7 @@ func mapKeysInt(mm map[int]struct{}) []int {
 	for k := range mm {
 		ret = append(ret, k)
 	}
-	sort.Ints(ret)
+	slices.Sort(ret)
 	return ret
 }
 

--- a/main.go
+++ b/main.go
@@ -1065,11 +1065,22 @@ func remapLeastBusyPg(candidateMappings []pgMapping) (string, bool) {
 		bestScore   = int(math.MaxInt32)
 		bestMapping pgMapping
 	)
-	// Look for a candidate OSD to remap to that has the lowest reservation
-	// score. We consider the remote reservation count (the count of
-	// backfills in which this OSD is the target) to be more important than
-	// the local reservation count (the count of backfills for which this
-	// OSD is primary), and thus apply a weight to it.
+	// Select the candidate OSD to remap to with the lowest "busy" score.
+	// The score is calculated as: min(remoteReservations, cap)*2 + currentPGCount, where cap is typically 2.
+	//
+	// Why cap=2?
+	// - With cap=2, OSDs with 0, 1, or 2 remote reservations are strongly preferred for new PGs, but once an OSD reaches 2 reservations,
+	//   the penalty stops increasing. This ensures that OSDs with high reservations are not permanently excluded from receiving PGs,
+	//   and the algorithm will begin to balance PG counts more evenly once all targets are "full enough".
+	// - This value was chosen because, in practice, reservation slots above 2 are often already busy, and further penalizing them
+	//   does not improve balance but can lead to unnecessary skew (overloading OSDs with fewer reservations).
+	//
+	// Impact of higher cap values:
+	// - Raising the cap (e.g., to 3, 4, or 5) makes the algorithm avoid OSDs with high reservations for longer, causing PGs to pile up
+	//   on OSDs with fewer reservations. This can result in less even PG distribution and higher risk of overloading those OSDs.
+	// - Lower cap values (like 2) strike a balance between respecting reservation pressure and achieving even PG distribution.
+	//
+	// Once the capped penalty is reached for all OSDs, PGs are distributed to balance PG counts as evenly as possible across OSDs.
 	for _, m := range candidateMappings {
 		if !M.bs.hasRoomForRemap(m.PgID, m.Mapping.From, m.Mapping.To) {
 			M.changeState = updateChangeState(NoReservationAvailable)
@@ -1077,7 +1088,9 @@ func remapLeastBusyPg(candidateMappings []pgMapping) (string, bool) {
 		}
 
 		obs := M.bs.osd(m.Mapping.To)
-		score := obs.remoteReservations*10 + obs.localReservations
+		upPGs := getUpPGsForOsds([]int{m.Mapping.To})
+		currentPGCount := len(upPGs[m.Mapping.To])
+		score := min(obs.remoteReservations, 2)*2 + currentPGCount
 		if score < bestScore {
 			found = true
 			bestScore = score

--- a/main_test.go
+++ b/main_test.go
@@ -307,7 +307,7 @@ func TestCalcPgMappingsToUndoBackfill(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			setupTest(t)
-			defer teardownTest(t)
+			t.Cleanup(func() { teardownTest(t) })
 
 			runOsdDump = func() (string, error) { return osdDumpOut, nil }
 			runPgDumpPgsBrief = func() (string, error) { return pgDumpOut, nil }
@@ -352,7 +352,7 @@ func TestCalcPgMappingsToUndoBackfill(t *testing.T) {
 
 func TestCountCurrentBackfills(t *testing.T) {
 	setupTest(t)
-	defer teardownTest(t)
+	t.Cleanup(func() { teardownTest(t) })
 	out := `
 [
  { "pgid": "1.32", "up": [ 7, 5, 9], "acting": [ 7, 5, 9 ] },
@@ -448,7 +448,7 @@ func TestCalcPgMappingsToUndoUpmaps(t *testing.T) {
 
 	t.Run("source OSDs specified", func(t *testing.T) {
 		setupTest(t)
-		defer teardownTest(t)
+		t.Cleanup(func() { teardownTest(t) })
 
 		runOsdDump = func() (string, error) { return osdDumpOut, nil }
 		runPgDumpPgsBrief = func() (string, error) { return pgDumpOut, nil }
@@ -471,7 +471,7 @@ func TestCalcPgMappingsToUndoUpmaps(t *testing.T) {
 
 	t.Run("target OSDs specified", func(t *testing.T) {
 		setupTest(t)
-		defer teardownTest(t)
+		t.Cleanup(func() { teardownTest(t) })
 
 		runOsdDump = func() (string, error) { return osdDumpOut, nil }
 		runPgDumpPgsBrief = func() (string, error) { return pgDumpOut, nil }
@@ -492,7 +492,7 @@ func TestCalcPgMappingsToUndoUpmaps(t *testing.T) {
 
 	t.Run("max-backfills specified", func(t *testing.T) {
 		setupTest(t)
-		defer teardownTest(t)
+		t.Cleanup(func() { teardownTest(t) })
 
 		runOsdDump = func() (string, error) { return osdDumpOut, nil }
 		runPgDumpPgsBrief = func() (string, error) { return pgDumpOut, nil }
@@ -600,7 +600,7 @@ func TestCalcPgMappingsToBalanceHost(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			setupTest(t)
-			defer teardownTest(t)
+			t.Cleanup(func() { teardownTest(t) })
 
 			runOsdDump = func() (string, error) { return osdDumpOut, nil }
 			runPgDumpPgsBrief = func() (string, error) { return pgDumpOut, nil }
@@ -825,7 +825,7 @@ func TestCalcPgMappingsToDrainOsd(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			setupTest(t)
-			defer teardownTest(t)
+			t.Cleanup(func() { teardownTest(t) })
 
 			runOsdDump = func() (string, error) { return osdDumpOut, nil }
 			runOsdTree = func() (string, error) { return osdTreeOut, nil }
@@ -858,6 +858,7 @@ type expectedMapping struct {
 }
 
 func validateDirtyMappings(t *testing.T, expected []expectedMapping) {
+	t.Helper()
 	puis := M.dirtyUpmapItems()
 	require.Len(t, puis, len(expected))
 
@@ -869,7 +870,7 @@ func validateDirtyMappings(t *testing.T, expected []expectedMapping) {
 
 func TestParseMaxBackfillReservations(t *testing.T) {
 	setupTest(t)
-	defer teardownTest(t)
+	t.Cleanup(func() { teardownTest(t) })
 	osdTreeOut := `
 {
   "nodes": [
@@ -900,9 +901,35 @@ func TestParseMaxBackfillReservations(t *testing.T) {
 	require.Equal(t, 6, M.bs.getMaxBackfillReservations(133))
 }
 
+func TestParseMaxBackfillReservationsInvalidSpecifier(t *testing.T) {
+	setupTest(t)
+	t.Cleanup(func() { teardownTest(t) })
+
+	runOsdDump = func() (string, error) { return `{"osds":[],"pg_upmap_items":[]}`, nil }
+	runPgDumpPgsBrief = func() (string, error) { return `[]`, nil }
+	runOsdPoolLs = func() (string, error) {
+		return `[{"pool_id":1,"pool_name":"replicated","erasure_code_profile":""}]`, nil
+	}
+
+	cmd := &cobra.Command{}
+	cmd.Flags().StringSlice("max-backfill-reservations", []string{"4", "invalidspec"}, "")
+
+	M = mustGetCurrentMappingState()
+
+	defer func() {
+		msg := recover()
+		require.NotNil(t, msg)
+		e, ok := msg.(error)
+		require.True(t, ok)
+		require.Contains(t, e.Error(), "is not a valid max-backfill-reservation specifier")
+	}()
+
+	mustParseMaxBackfillReservations(cmd)
+}
+
 func TestDeviceClassFilter(t *testing.T) {
 	setupTest(t)
-	defer teardownTest(t)
+	t.Cleanup(func() { teardownTest(t) })
 	osdTreeOut := `
 	{
 		"nodes": [
@@ -941,6 +968,7 @@ func TestDeviceClassFilter(t *testing.T) {
 }
 
 func setupTest(t *testing.T) {
+	t.Helper()
 	// By default, report all pools we use as replicated; if there are EC
 	// tests, they can override this implementation.
 	osdPoolDetailout := `
@@ -957,10 +985,13 @@ func setupTest(t *testing.T) {
 }
 
 func teardownTest(t *testing.T) {
+	t.Helper()
 	savedOsdDumpOut = nil
 	savedOsdPoolsDetails = nil
 	savedParsedOsdTree = nil
 	savedPgDumpPgsBrief = nil
+	savedPgUpmapItemMap = nil
+	savedPgUpmapItemMapSource = nil
 
 	runOsdDump = nil
 	runOsdPoolLs = nil

--- a/main_test.go
+++ b/main_test.go
@@ -16,6 +16,7 @@ package main
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/spf13/cobra"
@@ -347,6 +348,56 @@ func TestCalcPgMappingsToUndoBackfill(t *testing.T) {
 
 			validateDirtyMappings(t, tt.expected)
 		})
+	}
+}
+
+func TestCalcPgMappingsToUndoBackfillAppliesAllQueuedRemapsBeforeReturn(t *testing.T) {
+	setupTest(t)
+	t.Cleanup(func() { teardownTest(t) })
+
+	const pgCount = 200
+	var sb strings.Builder
+	sb.WriteString("[\n")
+	for i := range pgCount {
+		if i > 0 {
+			sb.WriteString(",\n")
+		}
+		fmt.Fprintf(
+			&sb,
+			` { "pgid": "1.%x", "up": [ 1, 100, 3 ], "acting": [ 1, 101, 3 ], "state": "backfill_wait" }`,
+			i,
+		)
+	}
+	sb.WriteString("\n]\n")
+	pgDumpOut := sb.String()
+
+	runOsdDump = func() (string, error) {
+		return `{"pg_upmap_items":[]}`, nil
+	}
+	runPgDumpPgsBrief = func() (string, error) {
+		return pgDumpOut, nil
+	}
+
+	prevConcurrency := concurrency
+	concurrency = 1
+	t.Cleanup(func() { concurrency = prevConcurrency })
+
+	M = mustGetCurrentMappingState()
+	calcPgMappingsToUndoBackfill(
+		true, // excludeBackfilling
+		false,
+		false,
+		map[int]struct{}{},
+		map[int]struct{}{},
+		map[int]struct{}{},
+		map[int]struct{}{},
+		map[int]struct{}{},
+	)
+
+	puis := M.dirtyUpmapItems()
+	require.Len(t, puis, pgCount)
+	for _, pui := range puis {
+		require.Equal(t, []mapping{{From: 100, To: 101, dirty: true}}, pui.Mappings)
 	}
 }
 

--- a/mappingstate.go
+++ b/mappingstate.go
@@ -17,7 +17,6 @@ package main
 import (
 	"fmt"
 	"slices"
-	"sort"
 	"strings"
 	"sync"
 
@@ -54,7 +53,7 @@ func updateChangeState(wantedState changeStateType) changeStateType {
 func mustGetCurrentMappingState() *mappingState {
 	osdDumpOut := osdDump()
 	items := osdDumpOut.PgUpmapItems
-	sort.Slice(items, func(i, j int) bool { return items[i].PgID < items[j].PgID })
+	slices.SortFunc(items, func(a, b *pgUpmapItem) int { return strings.Compare(a.PgID, b.PgID) })
 	sanitizeStaleUpmaps(items)
 	return &mappingState{
 		pgUpmapItems: osdDumpOut.PgUpmapItems,
@@ -63,7 +62,26 @@ func mustGetCurrentMappingState() *mappingState {
 }
 
 func sanitizeStaleUpmaps(puis []*pgUpmapItem) {
-	pgBriefs := pgBriefMap()
+	if len(puis) == 0 {
+		return
+	}
+
+	// Build a set of only the PGIDs that have upmap items. In a large cluster
+	// there can be tens of thousands of PGs, but only a small fraction will
+	// have upmap entries. Building an index of every PG would over-allocate;
+	// instead we iterate pgDumpPgsBrief() once and keep only the entries we
+	// actually need, keeping the map proportional to the upmap item count.
+	targetPGIDs := make(map[string]struct{}, len(puis))
+	for _, pui := range puis {
+		targetPGIDs[pui.PgID] = struct{}{}
+	}
+
+	pgBriefs := make(map[string]*pgBriefItem, len(targetPGIDs))
+	for _, pgb := range pgDumpPgsBrief() {
+		if _, ok := targetPGIDs[pgb.PgID]; ok {
+			pgBriefs[pgb.PgID] = pgb
+		}
+	}
 
 	hasOSD := func(osdids []int, osdid int) bool {
 		return slices.Contains(osdids, osdid)
@@ -116,7 +134,7 @@ func (m *mappingState) tryRemap(pgid string, from, to int) error {
 			// simply remove it.
 			pui.Mappings[i].dirty = true
 			pui.removedMappings = append(pui.removedMappings, pui.Mappings[i])
-			pui.Mappings = append(pui.Mappings[0:i], pui.Mappings[i+1:]...)
+			pui.Mappings = slices.Delete(pui.Mappings, i, i+1)
 			m.bs.accountForRemap(pgid, from, to)
 			return nil
 		}
@@ -148,8 +166,10 @@ func (m *mappingState) mustRemap(pgid string, from, to int) {
 
 func (m *mappingState) findOrMakeUpmapItem(pgid string) *pgUpmapItem {
 	puis := m.pgUpmapItems
-	i := sort.Search(len(puis), func(i int) bool { return m.pgUpmapItems[i].PgID >= pgid })
-	if i < len(puis) && puis[i].PgID == pgid {
+	i, found := slices.BinarySearchFunc(puis, pgid, func(pui *pgUpmapItem, s string) int {
+		return strings.Compare(pui.PgID, s)
+	})
+	if found {
 		return puis[i]
 	}
 
@@ -157,10 +177,7 @@ func (m *mappingState) findOrMakeUpmapItem(pgid string) *pgUpmapItem {
 	pui := &pgUpmapItem{
 		PgID: pgid,
 	}
-	puis = append(puis, &pgUpmapItem{})
-	copy(puis[i+1:], puis[i:])
-	puis[i] = pui
-	m.pgUpmapItems = puis
+	m.pgUpmapItems = slices.Insert(puis, i, pui)
 
 	return pui
 }
@@ -244,7 +261,7 @@ func (m *mappingState) dirtyUpmapItems() []*pgUpmapItem {
 	m.l.Lock()
 	defer m.l.Unlock()
 
-	items := []*pgUpmapItem{}
+	items := make([]*pgUpmapItem, 0, len(m.pgUpmapItems))
 
 	for _, pui := range m.pgUpmapItems {
 		if pui.dirty {

--- a/mappingstate.go
+++ b/mappingstate.go
@@ -83,19 +83,22 @@ func sanitizeStaleUpmaps(puis []*pgUpmapItem) {
 		}
 	}
 
-	hasOSD := func(osdids []int, osdid int) bool {
-		return slices.Contains(osdids, osdid)
-	}
-
 	for _, pui := range puis {
 		pgBrief, ok := pgBriefs[pui.PgID]
 		if !ok {
 			continue
 		}
 
-		finalMappings := []mapping{}
+		upSet := make(map[int]struct{}, len(pgBrief.Up))
+		for _, osd := range pgBrief.Up {
+			upSet[osd] = struct{}{}
+		}
+
+		finalMappings := make([]mapping, 0, len(pui.Mappings))
 		for _, m := range pui.Mappings {
-			if hasOSD(pgBrief.Up, m.From) || !hasOSD(pgBrief.Up, m.To) {
+			_, fromInUp := upSet[m.From]
+			_, toInUp := upSet[m.To]
+			if fromInUp || !toInUp {
 				// This mapping has no effect on the PG and is
 				// thus stale, but Ceph hasn't cleaned it up.
 				// It will get in the way of our own decision

--- a/mappingstate_test.go
+++ b/mappingstate_test.go
@@ -138,3 +138,68 @@ func TestTryRemapRemovesExactOppositeMapping(t *testing.T) {
 	require.Equal(t, 5, dirty[0].removedMappings[0].From)
 	require.Equal(t, 6, dirty[0].removedMappings[0].To)
 }
+
+func TestSanitizeStaleUpmapsFiltersByUpSetAndLeavesUnknownPGUntouched(t *testing.T) {
+	setupTest(t)
+	t.Cleanup(func() { teardownTest(t) })
+
+	runOsdDump = func() (string, error) {
+		return `
+{
+  "osds": [],
+  "pg_upmap_items": [
+    {
+      "pgid": "1.1",
+      "mappings": [
+        { "from": 1, "to": 2 },
+        { "from": 4, "to": 5 },
+        { "from": 4, "to": 2 },
+        { "from": 2, "to": 3 }
+      ]
+    },
+    {
+      "pgid": "1.2",
+      "mappings": [
+        { "from": 8, "to": 9 }
+      ]
+    }
+  ]
+}
+`, nil
+	}
+
+	runPgDumpPgsBrief = func() (string, error) {
+		return `
+[
+  { "pgid": "1.1", "up": [ 1, 2, 3 ], "acting": [ 1, 2, 3 ], "state": "active+clean" }
+]
+`, nil
+	}
+
+	M = mustGetCurrentMappingState()
+
+	var p11, p12 *pgUpmapItem
+	for _, pui := range M.pgUpmapItems {
+		switch pui.PgID {
+		case "1.1":
+			p11 = pui
+		case "1.2":
+			p12 = pui
+		}
+	}
+
+	require.NotNil(t, p11)
+	require.NotNil(t, p12)
+
+	// Only mapping 4->2 should remain for 1.1.
+	require.Equal(t, []mapping{{From: 4, To: 2}}, p11.Mappings)
+	require.ElementsMatch(t, []mapping{
+		{From: 1, To: 2, dirty: true},
+		{From: 4, To: 5, dirty: true},
+		{From: 2, To: 3, dirty: true},
+	}, p11.staleMappings)
+
+	// PG 1.2 has no pg_brief entry; it should remain untouched.
+	require.Equal(t, []mapping{{From: 8, To: 9}}, p12.Mappings)
+	require.Empty(t, p12.staleMappings)
+}

--- a/mappingstate_test.go
+++ b/mappingstate_test.go
@@ -22,7 +22,7 @@ import (
 
 func TestGetMappings(t *testing.T) {
 	setupTest(t)
-	defer teardownTest(t)
+	t.Cleanup(func() { teardownTest(t) })
 	pgDumpOut := `
 [
  { "pgid": "1.1", "up": [ 1, 2, 4 ], "acting": [ 1, 2, 3 ], "state": "backfill_wait" },
@@ -99,4 +99,42 @@ func TestGetMappings(t *testing.T) {
 			require.ElementsMatch(t, tt.expected, got)
 		})
 	}
+}
+
+func TestTryRemapRemovesExactOppositeMapping(t *testing.T) {
+	setupTest(t)
+	t.Cleanup(func() { teardownTest(t) })
+
+	runOsdDump = func() (string, error) {
+		return `
+{
+  "osds": [],
+  "pg_upmap_items": [
+    { "pgid": "1.1", "mappings": [ { "from": 5, "to": 6 } ] }
+  ]
+}
+`, nil
+	}
+	runPgDumpPgsBrief = func() (string, error) {
+		return `
+[
+  { "pgid": "1.1", "up": [ 6 ], "acting": [ 5 ], "state": "active+remapped" }
+]
+`, nil
+	}
+	runOsdPoolLs = func() (string, error) {
+		return `[{"pool_id":1,"pool_name":"replicated","erasure_code_profile":""}]`, nil
+	}
+
+	M = mustGetCurrentMappingState()
+	err := M.tryRemap("1.1", 6, 5)
+	require.NoError(t, err)
+
+	require.Empty(t, M.getMappings(withPgid("1.1")))
+	dirty := M.dirtyUpmapItems()
+	require.Len(t, dirty, 1)
+	require.Len(t, dirty[0].Mappings, 0)
+	require.Len(t, dirty[0].removedMappings, 1)
+	require.Equal(t, 5, dirty[0].removedMappings[0].From)
+	require.Equal(t, 6, dirty[0].removedMappings[0].To)
 }


### PR DESCRIPTION
Introduces opportunistic balancing of pgs during Drain.  Still penalizing OSDs with high reservations initially, but capping the penalty to attempt a balanced distribution of pgs count.